### PR TITLE
fix(security): block open redirect in login redirect target

### DIFF
--- a/service/auth.go
+++ b/service/auth.go
@@ -543,11 +543,23 @@ func decodeState(state string) string {
 	if err != nil {
 		return "/"
 	}
-	redirect := string(data)
-	if !strings.HasPrefix(redirect, "/") {
+	return safeRedirectPath(string(data))
+}
+
+// safeRedirectPath 仅放行站内相对路径，拦截开放重定向。浏览器会忽略 URL 中的
+// Tab/换行/回车，并把 //host 或 /\host 解析为协议相对的跨站地址，因此先剥离这些
+// 控制字符，再拒绝 // 与 /\ 前缀。
+func safeRedirectPath(redirect string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return -1
+		}
+		return r
+	}, redirect)
+	if !strings.HasPrefix(cleaned, "/") || strings.HasPrefix(cleaned, "//") || strings.HasPrefix(cleaned, "/\\") {
 		return "/"
 	}
-	return redirect
+	return cleaned
 }
 
 func RequestOrigin(r *http.Request) string {

--- a/service/auth_redirect_test.go
+++ b/service/auth_redirect_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestSafeRedirectPath(t *testing.T) {
+	cases := map[string]string{
+		"/":                    "/",
+		"/canvas/abc":          "/canvas/abc",
+		"/login?redirect=/x":   "/login?redirect=/x",
+		"":                     "/",
+		"//evil.com":           "/",
+		"/\\evil.com":          "/",
+		"https://evil.com":     "/",
+		"http://evil.com":      "/",
+		"javascript:alert(1)":  "/",
+		"evil.com":             "/",
+		"/\t/evil.com":         "/", // browsers strip the tab → //evil.com
+		"/normal\tpath":        "/normalpath",
+	}
+	for in, want := range cases {
+		if got := safeRedirectPath(in); got != want {
+			t.Errorf("safeRedirectPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDecodeStateRejectsOpenRedirect(t *testing.T) {
+	for _, in := range []string{"//evil.com", "/\\evil.com", "https://evil.com"} {
+		state := base64.RawURLEncoding.EncodeToString([]byte(in))
+		if got := decodeState(state); got != "/" {
+			t.Errorf("decodeState(state(%q)) = %q, want \"/\"", in, got)
+		}
+	}
+	state := base64.RawURLEncoding.EncodeToString([]byte("/canvas/1"))
+	if got := decodeState(state); got != "/canvas/1" {
+		t.Errorf("decodeState(state(/canvas/1)) = %q, want /canvas/1", got)
+	}
+}

--- a/web/src/app/(user)/login/page.tsx
+++ b/web/src/app/(user)/login/page.tsx
@@ -15,6 +15,16 @@ type LoginFormValues = {
     confirmPassword?: string;
 };
 
+// 仅放行站内相对路径，拦截开放重定向。浏览器会忽略 URL 中的 Tab/换行/回车，并把
+// //host 或 /\host 解析为协议相对的跨站地址，因此先剥离控制字符，再拒绝 // 与 /\ 前缀。
+function safeRedirect(value: string | null): string {
+    const cleaned = (value ?? "").replace(/[\t\n\r]/g, "");
+    if (!cleaned.startsWith("/") || cleaned.startsWith("//") || cleaned.startsWith("/\\")) {
+        return "/";
+    }
+    return cleaned;
+}
+
 export default function LoginPage() {
     return (
         <Suspense fallback={null}>
@@ -34,7 +44,7 @@ function LoginContent() {
     const linuxDoEnabled = useConfigStore((state) => state.publicSettings?.auth?.linuxDo?.enabled === true);
     const allowRegister = useConfigStore((state) => state.publicSettings?.auth?.allowRegister !== false);
     const [mode, setMode] = useState<"login" | "register">("login");
-    const redirect = searchParams.get("redirect") || "/";
+    const redirect = safeRedirect(searchParams.get("redirect"));
 
     useEffect(() => {
         const token = searchParams.get("token");
@@ -44,7 +54,7 @@ function LoginContent() {
         void fetchCurrentUser(token).then((user) => {
             setSession(token, user);
             message.success("登录成功");
-            router.replace(redirect.startsWith("/") ? redirect : "/");
+            router.replace(redirect);
             router.refresh();
         });
     }, [message, redirect, router, searchParams, setSession]);
@@ -66,7 +76,7 @@ function LoginContent() {
             const action = mode === "register" ? register : login;
             const user = await action({ username: values.username, password: values.password });
             message.success(mode === "register" ? "注册成功" : "登录成功");
-            router.replace(redirect.startsWith("/") ? redirect : "/");
+            router.replace(redirect);
             router.refresh();
             if (user.role !== "admin") router.replace("/");
         } catch (error) {


### PR DESCRIPTION
## Summary
The login redirect target was validated with a prefix-only check that
accepted any value beginning with a single slash. A protocol-relative URL
such as `//evil.com` (or a backslash variant like `/\evil.com`) passes that
check, so the browser resolves it to an external origin. This is an open
redirect (CWE-601). The same flawed check appears in two places, which is why
both are fixed here:

- `service/auth.go` — `decodeState()` validates the redirect carried in the
  Linux.do OAuth `state` parameter.
- `web/src/app/(user)/login/page.tsx` — the login page reads `?redirect=` and
  calls `router.replace(...)` after both the OAuth callback **and** a normal
  username/password login.

## Impact
An attacker sends a victim a link like
`https://<host>/login?redirect=//evil.com` (or supplies the same value through
the Linux.do `redirect` param). After the victim authenticates, the app
navigates the browser to `https://evil.com`. This is a credible phishing /
session-handoff vector — the post-login landing page is fully attacker-chosen
while the initial URL is on the trusted origin.

## Location
- `service/auth.go` — `decodeState` (redirect prefix check)
- `web/src/app/(user)/login/page.tsx` — `redirect` handling at the two
  `router.replace` sites

## Fix
Replace the single-slash prefix check with a stricter same-site relative-path
guard in both layers:
- Strip Tab / CR / LF first (browsers ignore these inside URLs, so
  `/\t/evil.com` would otherwise normalize back to `//evil.com`).
- Reject `//` and backslash-prefixed targets.
- Allow only genuine same-site relative paths (e.g. `/canvas/123`); anything
  else falls back to `/`.

No behavior change for legitimate relative redirects.

## Detected by
Aeon + semgrep (`go.lang.security.injection.open-redirect`)
- Severity: medium
- CWE-601 (URL Redirection to Untrusted Site / Open Redirect)

## Verification
- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./...` — ok (added `service/auth_redirect_test.go` covering
  `safeRedirectPath` and `decodeState`; the new cases fail against the previous
  prefix-only logic and pass with this fix). The repo had no prior tests.
- Frontend change is a small pure helper plus the two call sites; not built
  locally (no toolchain checked in), but it mirrors the verified Go guard.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to adjust the
approach if you'd prefer to handle this differently.
