### PR TITLE
ci: 增加 ARM 架构 Docker 镜像自动构建

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,9 +9,37 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE_NAME: ghcr.io/yusazh/infinite-canvas
+
 jobs:
-  build:
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+    steps:
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=
+
+  build:
+    needs: meta
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -23,20 +51,65 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=tag
-            type=sha,prefix=
-
-      - uses: docker/build-push-action@v6
+      - id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=app-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=app-${{ matrix.arch }}
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "$RUNNER_TEMP/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs:
+      - meta
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Create multi-arch manifest
+        shell: bash
+        env:
+          TAGS: ${{ needs.meta.outputs.tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              tag_args+=("-t" "$tag")
+            fi
+          done <<< "$TAGS"
+
+          digest_args=()
+          while IFS= read -r digest_file; do
+            digest_args+=("${IMAGE_NAME}@sha256:${digest_file}")
+          done < <(find "$RUNNER_TEMP/digests" -type f -printf '%f\n' | sort)
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docs-docker-image.yml
+++ b/.github/workflows/docs-docker-image.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           context: .
           file: ./docs/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docs-docker-image.yml
+++ b/.github/workflows/docs-docker-image.yml
@@ -9,9 +9,38 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE_NAME: ghcr.io/yusazh/infinite-canvas-docs
+
 jobs:
-  build:
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+    steps:
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+            type=sha,prefix=
+
+  build:
+    needs: meta
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -23,22 +52,66 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}-docs
-          tags: |
-            type=raw,value=latest
-            type=ref,event=tag
-            type=sha,prefix=
-
-      - uses: docker/build-push-action@v6
+      - id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docs/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docs
-          cache-to: type=gha,mode=max,scope=docs
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docs-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docs-${{ matrix.arch }}
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "$RUNNER_TEMP/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs:
+      - meta
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: docs-digests-*
+          merge-multiple: true
+
+      - name: Create multi-arch manifest
+        shell: bash
+        env:
+          TAGS: ${{ needs.meta.outputs.tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              tag_args+=("-t" "$tag")
+            fi
+          done <<< "$TAGS"
+
+          digest_args=()
+          while IFS= read -r digest_file; do
+            digest_args+=("${IMAGE_NAME}@sha256:${digest_file}")
+          done < <(find "$RUNNER_TEMP/digests" -type f -printf '%f\n' | sort)
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"


### PR DESCRIPTION
## 变更内容

- 为主应用 Docker 镜像增加 `linux/amd64` 和 `linux/arm64` 多架构发布支持
- 为文档站 Docker 镜像增加 `linux/amd64` 和 `linux/arm64` 多架构发布支持
- 使用原生 GitHub-hosted runner 并行构建不同架构：
  - `linux/amd64` 使用 `ubuntu-latest`
  - `linux/arm64` 使用 `ubuntu-24.04-arm`
- 每个架构单独构建并推送 digest，最后通过 `docker buildx imagetools create` 合并为多架构 manifest

## 背景说明

当前发布的 Docker 镜像只有 `amd64`，ARM 设备直接拉取镜像时无法获得原生 `arm64` 镜像。

直接在 x64 runner 上增加 `linux/arm64` 虽然可以生成 ARM 镜像，但会通过模拟方式构建，耗时明显增加。这里改为 amd64 / arm64 原生 runner 并行构建，在支持 ARM 镜像的同时保持较快的发布速度。

Closes #44

## 验证

- 主应用镜像 workflow 构建成功：
  https://github.com/YuSaZh/infinite-canvas/actions/runs/27093879954
- 文档站镜像 workflow 构建成功：
  https://github.com/YuSaZh/infinite-canvas/actions/runs/27093879970
- 已检查 commit tag `13418a4` 对应的 GHCR manifest，确认包含：
  - `linux/amd64`
  - `linux/arm64`

本次测试构建耗时：
- 主应用镜像约 4 分钟
- 文档站镜像约 2 分钟