### PR TITLE
fix: allow native wheel scrolling in textareas and scrollable containers inside canvas

### DIFF
--- a/web/src/app/(user)/canvas/components/canvas-node-prompt-panel.tsx
+++ b/web/src/app/(user)/canvas/components/canvas-node-prompt-panel.tsx
@@ -61,6 +61,7 @@ export function CanvasNodePromptPanel({ node, isRunning, onPromptChange, onConfi
     return (
         <div
             className="rounded-2xl border p-3 shadow-2xl backdrop-blur"
+            data-canvas-no-zoom
             style={{ background: theme.toolbar.panel, borderColor: theme.toolbar.border, color: theme.node.text }}
             onMouseDown={(event) => event.stopPropagation()}
             onPointerDown={(event) => event.stopPropagation()}

--- a/web/src/app/(user)/canvas/components/infinite-canvas.tsx
+++ b/web/src/app/(user)/canvas/components/infinite-canvas.tsx
@@ -65,7 +65,7 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
 
     const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
         const target = event.target instanceof Element ? event.target : null;
-        if (target?.closest("[data-canvas-no-zoom],.ant-modal,.ant-popover,.ant-dropdown,.ant-select-dropdown,.ant-picker-dropdown")) return;
+        if (target?.closest("textarea,[data-canvas-no-zoom],.ant-modal,.ant-popover,.ant-dropdown,.ant-select-dropdown,.ant-picker-dropdown")) return;
 
         const delta = -event.deltaY;
         const factor = Math.pow(1.1, delta / 100);
@@ -162,7 +162,19 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
         const container = containerRef.current;
         if (!container) return;
 
-        const preventWheelScroll = (event: WheelEvent) => event.preventDefault();
+        const preventWheelScroll = (event: WheelEvent) => {
+            const target = event.target;
+            // Allow native scrolling for textareas and elements with overflow scroll
+            if (target instanceof Element) {
+                if (target.tagName === 'TEXTAREA') return;
+                const style = window.getComputedStyle(target);
+                if (target.scrollHeight > target.clientHeight &&
+                    (style.overflowY === 'auto' || style.overflowY === 'scroll')) return;
+                if (target.scrollWidth > target.clientWidth &&
+                    (style.overflowX === 'auto' || style.overflowX === 'scroll')) return;
+            }
+            event.preventDefault();
+        };
         container.addEventListener("wheel", preventWheelScroll, { passive: false });
         return () => container.removeEventListener("wheel", preventWheelScroll);
     }, [containerRef]);


### PR DESCRIPTION
The canvas container installs a 'wheel' event listener with {passive: false} and calls preventDefault() unconditionally, which blocks native textarea scrolling and other scrollable containers inside the canvas.

Changes:
1. preventWheelScroll: skip preventDefault for TEXTAREA elements and elements with overflow:auto/scroll that can actually scroll
2. handleWheel: add 'textarea' to the closest() skip list so canvas zoom is not triggered when scrolling in textareas
3. canvas-node-prompt-panel: add data-canvas-no-zoom attribute to prevent wheel events from zooming the panel area