### PR TITLE
feat: add proxy mode & Docker host networking fix

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,5 +5,9 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3003:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - DOCKER_HOST_GATEWAY=host.docker.internal
     restart: unless-stopped

--- a/web/src/app/(user)/canvas/components/canvas-image-settings-popover.tsx
+++ b/web/src/app/(user)/canvas/components/canvas-image-settings-popover.tsx
@@ -6,6 +6,8 @@ import { Settings2 } from "lucide-react";
 import { Button } from "antd";
 
 import { ImageSettingsPanel, imageQualityLabel, imageSizeLabel } from "@/components/image-settings-panel";
+import { SeedreamImageSettingsPanel, seedreamSizeLabel } from "@/components/seedream-image-settings-panel";
+import { resolveAdapter } from "@/services/api/image-adapters";
 import { canvasThemes } from "@/lib/canvas-theme";
 import { useThemeStore } from "@/stores/use-theme-store";
 import type { AiConfig } from "@/stores/use-config-store";
@@ -27,9 +29,15 @@ export function CanvasImageSettingsPopover({ config, onConfigChange, onOpenChang
     const panelRef = useRef<HTMLDivElement>(null);
     const [open, setOpen] = useState(false);
     const [buttonRect, setButtonRect] = useState<DOMRect | null>(null);
+
+    // Resolve which adapter this config uses
+    const modelName = config.model || config.imageModel || "";
+    const adapter = resolveAdapter(modelName);
+    const isSeedream = adapter.id === "seedream";
+
     const quality = config.quality || "auto";
     const count = Math.max(1, Math.min(15, Math.floor(Math.abs(Number(config.count)) || 1)));
-    const activeSize = config.size || "auto";
+    const activeSize = config.size || (isSeedream ? "2K" : "auto");
     const updateOpen = (nextOpen: boolean) => {
         setOpen(nextOpen);
         onOpenChange?.(nextOpen);
@@ -58,15 +66,28 @@ export function CanvasImageSettingsPopover({ config, onConfigChange, onOpenChang
         };
     }, [onOpenChange, open]);
 
-    const panel = open && buttonRect ? <ImageSettingsPortal buttonRect={buttonRect} panelRef={panelRef} placement={placement} theme={theme} config={config} onConfigChange={onConfigChange} /> : null;
+    // Summary label shows differently for seedream vs default
+    const summaryLabel = isSeedream
+        ? seedreamSizeLabel(activeSize) + " · " + count + " 张"
+        : imageQualityLabel(quality) + " · " + imageSizeLabel(activeSize) + " · " + count + " 张";
+
+    const panel = open && buttonRect ? (
+        <ImageSettingsPortal
+            buttonRect={buttonRect}
+            panelRef={panelRef}
+            placement={placement}
+            theme={theme}
+            config={config}
+            onConfigChange={onConfigChange}
+            isSeedream={isSeedream}
+        />
+    ) : null;
 
     return (
         <>
             <span ref={buttonRef} className="inline-flex min-w-0">
                 <Button size="small" type="text" className={buttonClassName || "!h-8 !max-w-[180px] !justify-start !rounded-full !px-2.5"} style={{ background: theme.node.fill, color: theme.node.text }} icon={<Settings2 className="size-3.5" />} onClick={() => updateOpen(!open)}>
-                    <span className="truncate">
-                        {imageQualityLabel(quality)} · {imageSizeLabel(activeSize)} · {count} 张
-                    </span>
+                    <span className="truncate">{summaryLabel}</span>
                 </Button>
             </span>
             {panel}
@@ -81,6 +102,7 @@ function ImageSettingsPortal({
     theme,
     config,
     onConfigChange,
+    isSeedream,
 }: {
     buttonRect: DOMRect;
     panelRef: RefObject<HTMLDivElement | null>;
@@ -88,6 +110,7 @@ function ImageSettingsPortal({
     theme: (typeof canvasThemes)[keyof typeof canvasThemes];
     config: AiConfig;
     onConfigChange: (key: keyof AiConfig, value: string) => void;
+    isSeedream: boolean;
 }) {
     const width = 356;
     const gap = 8;
@@ -97,7 +120,7 @@ function ImageSettingsPortal({
     const left = alignCenter ? buttonRect.left + buttonRect.width / 2 - width / 2 : alignRight ? buttonRect.right - width : buttonRect.left;
     const topPlacement = placement?.startsWith("top");
     const style = {
-        position: "fixed",
+        position: "fixed" as const,
         zIndex: 1200,
         width,
         left: Math.max(margin, Math.min(window.innerWidth - width - margin, left)),
@@ -108,7 +131,11 @@ function ImageSettingsPortal({
         padding: 18,
         overflowY: "auto",
         color: theme.node.text,
-    } as const;
+    };
+
+    const panelChange = (key: "quality" | "size" | "count", value: string) => {
+        onConfigChange(key, value);
+    };
 
     return createPortal(
         <div
@@ -119,7 +146,11 @@ function ImageSettingsPortal({
             onMouseDown={(event) => event.stopPropagation()}
             onClick={(event) => event.stopPropagation()}
         >
-            <ImageSettingsPanel config={config} onConfigChange={(key, value) => onConfigChange(key, value)} theme={theme} className="space-y-4" />
+            {isSeedream ? (
+                <SeedreamImageSettingsPanel config={config} onConfigChange={panelChange} theme={theme} className="space-y-4" />
+            ) : (
+                <ImageSettingsPanel config={config} onConfigChange={panelChange} theme={theme} className="space-y-4" />
+            )}
         </div>,
         document.body,
     );

--- a/web/src/app/(user)/image/page.tsx
+++ b/web/src/app/(user)/image/page.tsx
@@ -7,6 +7,8 @@ import localforage from "localforage";
 import { saveAs } from "file-saver";
 
 import { ImageSettingsPanel } from "@/components/image-settings-panel";
+import { SeedreamImageSettingsPanel } from "@/components/seedream-image-settings-panel";
+import { resolveAdapter } from "@/services/api/image-adapters";
 import { ModelPicker } from "@/components/model-picker";
 import { PromptSelectDialog } from "@/components/prompts/prompt-select-dialog";
 import { AssetPickerModal, type InsertAssetPayload } from "@/app/(user)/canvas/components/asset-picker-modal";
@@ -481,6 +483,8 @@ export default function ImagePage() {
 
 function GenerationSettings({ config, model, updateConfig, openConfigDialog }: { config: AiConfig; model: string; updateConfig: UpdateAiConfig; openConfigDialog: (shouldPromptContinue?: boolean) => void }) {
     const theme = canvasThemes[useThemeStore((state) => state.theme)];
+    const adapter = resolveAdapter(model);
+    const isSeedream = adapter.id === "seedream";
 
     return (
         <>
@@ -489,7 +493,11 @@ function GenerationSettings({ config, model, updateConfig, openConfigDialog }: {
                 <ModelPicker config={config} value={model} onChange={(value) => updateConfig("imageModel", value)} capability="image" fullWidth onMissingConfig={() => openConfigDialog(false)} />
             </label>
             <div className="col-span-2">
-                <ImageSettingsPanel config={config} onConfigChange={(key, value) => updateConfig(key, value)} theme={theme} showTitle={false} className="space-y-4" maxCount={10} />
+                {isSeedream ? (
+                    <SeedreamImageSettingsPanel config={config} onConfigChange={(key, value) => updateConfig(key, value)} theme={theme} showTitle={false} className="space-y-4" maxCount={10} />
+                ) : (
+                    <ImageSettingsPanel config={config} onConfigChange={(key, value) => updateConfig(key, value)} theme={theme} showTitle={false} className="space-y-4" maxCount={10} />
+                )}
             </div>
         </>
     );

--- a/web/src/app/api/ai-proxy/route.ts
+++ b/web/src/app/api/ai-proxy/route.ts
@@ -65,20 +65,19 @@ async function proxyRequest(request: NextRequest, method: string) {
             redirect: "manual",
         });
 
-        const responseHeaders = new Headers();
-        const passThroughHeaders = [
-            "content-type", "content-length", "content-disposition",
-            "cache-control", "etag", "x-request-id",
-        ];
-        for (const key of passThroughHeaders) {
-            const value = response.headers.get(key);
-            if (value) responseHeaders.set(key, value);
-        }
+        // Read response as text to avoid issues with gzip/content-encoding forwarding
+        const responseText = await response.text();
+        console.log("[AI Proxy] Response body length:", responseText.length);
 
-        return new Response(response.body, {
+        // Build safe headers - DO NOT forward Content-Encoding (fetch auto-decompresses)
+        // or Content-Length (it changes after re-serialization).
+        const forwardedHeaders = new Headers();
+        forwardedHeaders.set("Content-Type", "application/json");
+
+        return new Response(responseText, {
             status: response.status,
             statusText: response.statusText,
-            headers: responseHeaders,
+            headers: forwardedHeaders,
         });
     } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {

--- a/web/src/app/api/ai-proxy/route.ts
+++ b/web/src/app/api/ai-proxy/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const AI_PROXY_TIMEOUT_MS = 300000; // 5 min
+const LOCAL_HOSTNAMES = new Set(["127.0.0.1", "localhost"]);
+
+/** When running inside Docker, 127.0.0.1/localhost points to the container,
+ * not the host. Rewrite to DOCKER_HOST_GATEWAY so the proxy can reach
+ * services running on the host machine (e.g. sub2api/Cherry Studio at port 8751). */
+function resolveProxyTarget(target: string): string {
+  const gateway = process.env.DOCKER_HOST_GATEWAY;
+  if (!gateway) return target;
+
+  try {
+    const url = new URL(target);
+    if (LOCAL_HOSTNAMES.has(url.hostname)) {
+      url.hostname = gateway;
+      return url.toString();
+    }
+  } catch {
+    // invalid URL, return as-is
+  }
+  return target;
+}
+
+async function proxyRequest(request: NextRequest, method: string) {
+    const rawTarget = request.headers.get("x-ai-proxy-target") || "";
+    const target = resolveProxyTarget(rawTarget);
+    const auth = request.headers.get("x-ai-proxy-auth") || "";
+    if (!target) return new Response("Missing x-ai-proxy-target", { status: 400 });
+
+    let url: URL;
+    try {
+        url = new URL(target);
+    } catch {
+        return new Response("Invalid x-ai-proxy-target", { status: 400 });
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return new Response("Unsupported target protocol", { status: 400 });
+    }
+
+    const headers = new Headers();
+    if (auth) headers.set("Authorization", auth);
+
+    const contentType = request.headers.get("content-type");
+    if (contentType) headers.set("Content-Type", contentType);
+
+    const accept = request.headers.get("accept");
+    if (accept) headers.set("Accept", accept);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), AI_PROXY_TIMEOUT_MS);
+    try {
+        const body = method === "GET" || method === "HEAD" || method === "DELETE"
+            ? undefined
+            : await request.arrayBuffer();
+
+        const response = await fetch(url, {
+            method,
+            headers,
+            body: body?.byteLength ? body : undefined,
+            signal: controller.signal,
+            redirect: "manual",
+        });
+
+        const responseHeaders = new Headers();
+        const passThroughHeaders = [
+            "content-type", "content-length", "content-disposition",
+            "cache-control", "etag", "x-request-id",
+        ];
+        for (const key of passThroughHeaders) {
+            const value = response.headers.get(key);
+            if (value) responseHeaders.set(key, value);
+        }
+
+        return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: responseHeaders,
+        });
+    } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+            return new Response("AI proxy timeout", { status: 504 });
+        }
+        return new Response(
+            error instanceof Error ? error.message : "AI proxy error",
+            { status: 502 },
+        );
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+export async function GET(request: NextRequest) {
+    return proxyRequest(request, "GET");
+}
+
+export async function POST(request: NextRequest) {
+    return proxyRequest(request, "POST");
+}
+
+export async function DELETE(request: NextRequest) {
+    return proxyRequest(request, "DELETE");
+}

--- a/web/src/components/layout/app-config-modal.tsx
+++ b/web/src/components/layout/app-config-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { App, Button, Form, Input, Modal, Progress, Segmented, Select, Tabs } from "antd";
+import { App, Button, Form, Input, Modal, Progress, Segmented, Select, Switch, Tabs } from "antd"
 import { CircleAlert, Cloud, Plus, RefreshCw, Trash2, Wifi } from "lucide-react";
 import { useState } from "react";
 
@@ -121,7 +121,7 @@ export function AppConfigModal() {
         }
         setLoadingChannelId(channel.id);
         try {
-            const models = await fetchChannelModels(channel);
+            const models = await fetchChannelModels(channel, config.proxyEnabled);
             updateChannels(config.channels.map((item) => (item.id === channel.id ? { ...item, models } : item)));
             message.success(`${channel.name} 模型列表已更新`);
         } catch (error) {
@@ -139,7 +139,7 @@ export function AppConfigModal() {
         }
         setLoadingChannelId("all");
         try {
-            const entries = await Promise.all(runnable.map(async (channel) => [channel.id, await fetchChannelModels(channel)] as const));
+            const entries = await Promise.all(runnable.map(async (channel) => [channel.id, await fetchChannelModels(channel, config.proxyEnabled)] as const));
             const modelMap = new Map(entries);
             updateChannels(config.channels.map((channel) => (modelMap.has(channel.id) ? { ...channel, models: modelMap.get(channel.id) || [] } : channel)));
             message.success("模型列表已更新");
@@ -291,7 +291,16 @@ export function AppConfigModal() {
                                             </div>
                                         </section>
                                     ))}
+                            </div>
+                            <div className="mt-3 rounded-lg border border-stone-200 p-3 dark:border-stone-800">
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <div className="text-sm font-semibold">AI API 代理模式</div>
+                                        <div className="mt-1 text-xs text-stone-500">通过服务端转发 AI 请求，解决跨域（CORS）问题。本地 API（如 Cherry Studio）需开启此选项。</div>
+                                    </div>
+                                    <Switch checked={config.proxyEnabled} onChange={(checked) => updateConfig("proxyEnabled", checked)} />
                                 </div>
+                            </div>
                             </Form>
                         ),
                     },

--- a/web/src/components/seedream-image-settings-panel.tsx
+++ b/web/src/components/seedream-image-settings-panel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+import { ImageSettingsTheme } from "@/components/image-settings-panel";
+import type { CanvasTheme } from "@/lib/canvas-theme";
+import { seedreamAdapter } from "@/services/api/image-adapters";
+import type { AiConfig } from "@/stores/use-config-store";
+
+const SEEDREAM_PRESETS = seedreamAdapter.ui.presetSizes || [];
+
+type SeedreamImageSettingsPanelProps = {
+  config: AiConfig;
+  onConfigChange: (key: "quality" | "size" | "count", value: string) => void;
+  theme: CanvasTheme;
+  showTitle?: boolean;
+  className?: string;
+  maxCount?: number;
+};
+
+export function SeedreamImageSettingsPanel({
+  config,
+  onConfigChange,
+  theme,
+  showTitle = true,
+  className = "w-[320px] space-y-4 rounded-2xl px-1 py-0.5",
+  maxCount = 15,
+}: SeedreamImageSettingsPanelProps) {
+  const count = Math.max(1, Math.min(maxCount, Math.floor(Math.abs(Number(config.count)) || 1)));
+  const activeSize = config.size || "2K";
+  const is2k = !activeSize.startsWith("4K");
+  const filteredSizes = SEEDREAM_PRESETS.filter((s) => is2k ? s.id.startsWith("2K") : s.id.startsWith("4K"));
+
+  const selectSize = (value: string) => {
+    onConfigChange("size", value);
+  };
+
+  return (
+    <ImageSettingsTheme theme={theme}>
+      <div
+        className={className}
+        style={{ color: theme.node.text }}
+        onMouseDown={(event) => {
+          event.stopPropagation();
+          if (event.target instanceof HTMLInputElement) return;
+          if (document.activeElement instanceof HTMLInputElement && event.currentTarget.contains(document.activeElement))
+            document.activeElement.blur();
+        }}
+      >
+        {showTitle ? <div className="text-lg font-semibold">图像设置</div> : null}
+
+        {/* Resolution toggle: 2K / 4K */}
+        <div className="space-y-2.5">
+          <div className="text-xs font-medium" style={{ color: theme.node.muted }}>
+            分辨率
+          </div>
+          <div className="flex gap-2.5">
+            <button
+              type="button"
+              className="h-9 flex-1 cursor-pointer rounded-full border px-2 text-sm transition hover:opacity-80"
+              style={{
+                background: "transparent",
+                borderColor: is2k ? theme.node.text : theme.node.stroke,
+                color: theme.node.text,
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={() => {
+                if (!is2k) selectSize("2K");
+              }}
+            >
+              2K
+            </button>
+            <button
+              type="button"
+              className="h-9 flex-1 cursor-pointer rounded-full border px-2 text-sm transition hover:opacity-80"
+              style={{
+                background: "transparent",
+                borderColor: !is2k ? theme.node.text : theme.node.stroke,
+                color: theme.node.text,
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={() => {
+                if (is2k) selectSize("4K");
+              }}
+            >
+              4K
+            </button>
+          </div>
+        </div>
+
+        {/* Size presets grid */}
+        <div className="space-y-2.5">
+          <div className="text-xs font-medium" style={{ color: theme.node.muted }}>
+            尺寸
+          </div>
+          <div className="grid grid-cols-4 gap-2.5">
+            {filteredSizes.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="flex h-[72px] cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border bg-transparent text-sm transition hover:opacity-80"
+                style={{
+                  borderColor: activeSize === item.id ? theme.node.text : theme.node.stroke,
+                  background: "transparent",
+                  color: theme.node.text,
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={() => selectSize(item.id)}
+              >
+                <AspectIcon
+                  width={item.width}
+                  height={item.height}
+                  color={activeSize === item.id ? theme.node.text : theme.node.muted}
+                />
+                <span>{item.label}</span>
+              </button>
+            ))}
+          </div>
+          <div className="text-xs" style={{ color: theme.node.muted }}>
+            {filteredSizes.find((s) => s.id === activeSize)
+              ? filteredSizes.find((s) => s.id === activeSize)!.width + " x " + filteredSizes.find((s) => s.id === activeSize)!.height
+              : ""}
+          </div>
+        </div>
+
+        {/* Count */}
+        <div className="space-y-2.5">
+          <div className="text-xs font-medium" style={{ color: theme.node.muted }}>
+            生成张数
+          </div>
+          <div className="grid grid-cols-4 gap-2.5">
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className="h-9 cursor-pointer rounded-full border px-2 text-sm transition hover:opacity-80"
+                style={{
+                  background: "transparent",
+                  borderColor: count === value ? theme.node.text : theme.node.stroke,
+                  color: theme.node.text,
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={() => onConfigChange("count", String(value))}
+              >
+                {value} 张
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </ImageSettingsTheme>
+  );
+}
+
+function AspectIcon({
+  width,
+  height,
+  color,
+}: {
+  width: number;
+  height: number;
+  color: string;
+}) {
+  const ratio = width / Math.max(1, height);
+  const boxWidth = ratio >= 1 ? 24 : Math.max(10, 24 * ratio);
+  const boxHeight = ratio >= 1 ? Math.max(10, 24 / ratio) : 24;
+  return (
+    <span className="grid h-7 w-9 place-items-center">
+      <span className="border-2" style={{ width: boxWidth, height: boxHeight, borderColor: color }} />
+    </span>
+  );
+}
+
+/** Readable label for the current seedream size selection */
+export function seedreamSizeLabel(size: string) {
+  const preset = SEEDREAM_PRESETS.find((s) => s.id === size);
+  return preset ? preset.label : size;
+}

--- a/web/src/services/api/audio.ts
+++ b/web/src/services/api/audio.ts
@@ -6,17 +6,25 @@ import { buildApiUrl, resolveModelRequestConfig, type AiConfig } from "@/stores/
 
 type RequestOptions = { signal?: AbortSignal };
 
+let _proxyTargetUrl = "";
+
 function aiApiUrl(config: AiConfig, path: string) {
-    return buildApiUrl(config.baseUrl, path);
+    const directUrl = buildApiUrl(config.baseUrl, path);
+    _proxyTargetUrl = directUrl;
+    return config.proxyEnabled ? "/api/ai-proxy" : directUrl;
 }
 
 function aiHeaders(config: AiConfig) {
-    return {
-        Authorization: `Bearer ${config.apiKey}`,
-        "Content-Type": "application/json",
-    };
+    const headers: Record<string, string> = {};
+    if (config.proxyEnabled) {
+        headers["x-ai-proxy-target"] = _proxyTargetUrl;
+        headers["x-ai-proxy-auth"] = "Bearer " + config.apiKey;
+    } else {
+        headers["Authorization"] = "Bearer " + config.apiKey;
+    }
+    headers["Content-Type"] = "application/json";
+    return headers;
 }
-
 export async function requestAudioGeneration(config: AiConfig, prompt: string, options?: RequestOptions): Promise<Blob> {
     const requestConfig = resolveModelRequestConfig(config, config.model || config.audioModel);
     const model = requestConfig.model.trim();

--- a/web/src/services/api/image-adapters/gpt-image-2.ts
+++ b/web/src/services/api/image-adapters/gpt-image-2.ts
@@ -1,0 +1,178 @@
+import { nanoid } from "nanoid";
+import type { AiConfig } from "@/stores/use-config-store";
+import type { ImageAdapter, ImageResult, PresetSize } from "./types";
+
+// ---------------------------------------------------------------------------
+// Size / quality resolution (shared with the legacy path)
+// ---------------------------------------------------------------------------
+const QUALITY_BASE: Record<string, number> = {
+  low: 1024,
+  medium: 2048,
+  high: 2880,
+  standard: 1024,
+  hd: 2048,
+};
+const QUALITY_ALIASES: Record<string, string> = {
+  "1k": "low",
+  "2k": "medium",
+  "4k": "high",
+};
+const DEFAULT_IMAGE_SHORT_SIDE = 1024;
+const IMAGE_SIZE_STEP = 16;
+const IMAGE_MIN_PIXELS = 655360;
+const IMAGE_MAX_PIXELS = 8294400;
+const IMAGE_MAX_EDGE = 3840;
+const IMAGE_MAX_RATIO = 3;
+const IMAGE_OUTPUT_FORMAT = "png";
+
+function normalizeQuality(quality: string) {
+  const value = quality.trim().toLowerCase();
+  const normalized = QUALITY_ALIASES[value] || value;
+  return QUALITY_BASE[normalized] ? normalized : undefined;
+}
+
+function parseImageRatio(value: string) {
+  const parts = value.split(":");
+  if (parts.length !== 2) throw new Error("\u56fe\u50cf\u5c3a\u5bf8\u683c\u5f0f\u4e0d\u652f\u6301\uff0c\u8bf7\u4f7f\u7528 auto\u30019:16 \u6216 1024x1024");
+  const w = Number(parts[0]);
+  const h = Number(parts[1]);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) throw new Error("\u56fe\u50cf\u6bd4\u4f8b\u5fc5\u987b\u662f\u6b63\u6570\uff0c\u4f8b\u5982 9:16");
+  if (Math.max(w, h) / Math.min(w, h) > IMAGE_MAX_RATIO) throw new Error("\u56fe\u50cf\u5bbd\u9ad8\u6bd4\u4e0d\u80fd\u8d85\u8fc7 3:1\uff0c\u8bf7\u8c03\u6574\u5c3a\u5bf8");
+  return { width: w, height: h };
+}
+
+function parseImageDimensions(value: string) {
+  const match = value.match(/^(\\d+)x(\\d+)$/i);
+  if (!match) return null;
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+function validateImageSize(width: number, height: number) {
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0)
+    throw new Error("\u56fe\u50cf\u5c3a\u5bf8\u5fc5\u987b\u662f\u6b63\u6574\u6570\uff0c\u4f8b\u5982 1024x1024");
+  if (width % IMAGE_SIZE_STEP !== 0 || height % IMAGE_SIZE_STEP !== 0)
+    throw new Error("\u56fe\u50cf\u5c3a\u5bf8\u7684\u5bbd\u9ad8\u5fc5\u987b\u662f 16 \u7684\u500d\u6570\uff0c\u8bf7\u8c03\u6574\u5c3a\u5bf8");
+  if (Math.max(width, height) > IMAGE_MAX_EDGE)
+    throw new Error("\u56fe\u50cf\u5c3a\u5bf8\u6700\u957f\u8fb9\u4e0d\u80fd\u8d85\u8fc7 3840px\uff0c\u8bf7\u8c03\u6574\u5c3a\u5bf8");
+  if (Math.max(width, height) / Math.min(width, height) > IMAGE_MAX_RATIO)
+    throw new Error("\u56fe\u50cf\u5bbd\u9ad8\u6bd4\u4e0d\u80fd\u8d85\u8fc7 3:1\uff0c\u8bf7\u8c03\u6574\u5c3a\u5bf8");
+  const pixels = width * height;
+  if (pixels < IMAGE_MIN_PIXELS || pixels > IMAGE_MAX_PIXELS)
+    throw new Error("\u56fe\u50cf\u603b\u50cf\u7d20\u9700\u5728 655360 \u5230 8294400 \u4e4b\u95f4\uff0c\u8bf7\u8c03\u6574\u5c3a\u5bf8");
+}
+
+function resolveSize(quality: string | undefined, ratio: string): string {
+  const parsedRatio = parseImageRatio(ratio);
+  const basePixels = quality ? QUALITY_BASE[quality] : undefined;
+  const isLandscape = parsedRatio.width >= parsedRatio.height;
+  const longRatio = isLandscape ? parsedRatio.width / parsedRatio.height : parsedRatio.height / parsedRatio.width;
+  let longSide: number;
+  let shortSide: number;
+  if (basePixels) {
+    const targetPixels = basePixels * basePixels;
+    const longSideRaw = Math.sqrt(targetPixels * longRatio);
+    longSide = Math.floor(longSideRaw / IMAGE_SIZE_STEP) * IMAGE_SIZE_STEP;
+    shortSide = Math.round(longSide / longRatio / IMAGE_SIZE_STEP) * IMAGE_SIZE_STEP;
+  } else {
+    shortSide = DEFAULT_IMAGE_SHORT_SIDE;
+    longSide = Math.round((shortSide * longRatio) / IMAGE_SIZE_STEP) * IMAGE_SIZE_STEP;
+  }
+  const width = isLandscape ? longSide : shortSide;
+  const height = isLandscape ? shortSide : longSide;
+  validateImageSize(width, height);
+  return width + "x" + height;
+}
+
+function resolveRequestSize(quality: string | undefined, size: string) {
+  const value = size.trim();
+  if (!value || value.toLowerCase() === "auto") return undefined;
+  const dimensions = parseImageDimensions(value);
+  if (dimensions) {
+    validateImageSize(dimensions.width, dimensions.height);
+    return dimensions.width + "x" + dimensions.height;
+  }
+  if (value.includes(":")) return resolveSize(quality, value);
+  throw new Error("\u56fe\u50cf\u5c3a\u5bf8\u683c\u5f0f\u4e0d\u652f\u6301\uff0c\u8bf7\u4f7f\u7528 auto\u30019:16 \u6216 1024x1024");
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+function resolveImageDataUrl(item: Record<string, unknown>) {
+  if (typeof item.b64_json === "string" && item.b64_json) {
+    return "data:image/png;base64," + item.b64_json;
+  }
+  if (typeof item.url === "string" && item.url) {
+    return item.url;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Preset size options for the aspect-ratio grid
+// ---------------------------------------------------------------------------
+const aspectOptions: PresetSize[] = [
+  { id: "1:1", label: "1:1", width: 1024, height: 1024, icon: "square" },
+  { id: "3:2", label: "3:2", width: 1536, height: 1024, icon: "landscape" },
+  { id: "2:3", label: "2:3", width: 1024, height: 1536, icon: "portrait" },
+  { id: "4:3", label: "4:3", width: 1360, height: 1024, icon: "landscape" },
+  { id: "3:4", label: "3:4", width: 1024, height: 1360, icon: "portrait" },
+  { id: "16:9", label: "16:9", width: 1824, height: 1024, icon: "landscape" },
+  { id: "9:16", label: "9:16", width: 1024, height: 1824, icon: "portrait" },
+  { id: "1:1-2k", label: "1:1(2k)", size: "2048x2048", width: 2048, height: 2048, icon: "square" },
+  { id: "16:9-2k", label: "16:9(2k)", size: "2048x1152", width: 2048, height: 1152, icon: "landscape" },
+  { id: "9:16-2k", label: "9:16(2k)", size: "1152x2048", width: 1152, height: 2048, icon: "portrait" },
+  { id: "16:9-4k", label: "16:9(4k)", size: "3840x2160", width: 3840, height: 2160, icon: "landscape" },
+  { id: "9:16-4k", label: "9:16(4k)", size: "2160x3840", width: 2160, height: 3840, icon: "portrait" },
+  { id: "auto", label: "auto", width: 0, height: 0, icon: "square" },
+];
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+export const gptImage2Adapter: ImageAdapter = {
+  id: "gpt-image-2",
+  name: "OpenAI Compatible",
+
+  buildBody(config: AiConfig, prompt: string, count: number): Record<string, unknown> {
+    const quality = normalizeQuality(config.quality);
+    const requestSize = resolveRequestSize(quality, config.size);
+    const body: Record<string, unknown> = {
+      model: config.model,
+      prompt,
+      n: count,
+      response_format: "b64_json",
+      output_format: IMAGE_OUTPUT_FORMAT,
+    };
+    if (quality) body.quality = quality;
+    if (requestSize) body.size = requestSize;
+    return body;
+  },
+
+  parseResponse(raw: unknown): ImageResult[] {
+    let data = raw;
+    if (typeof data === "string") {
+      try { data = JSON.parse(data); } catch { throw new Error("\u63a5\u53e3\u8fd4\u56de\u5f02\u5e38\uff1a\u4e0d\u662f\u6709\u6548\u7684 JSON"); }
+    }
+    const payload = data as { data?: Record<string, unknown>[] };
+    if (!payload || !Array.isArray(payload.data)) {
+      throw new Error("\u63a5\u53e3\u8fd4\u56de\u5f02\u5e38\uff1a\u6570\u636e\u683c\u5f0f\u4e0d\u6b63\u786e");
+    }
+    const images = payload.data
+      .map(resolveImageDataUrl)
+      .filter((v): v is string => Boolean(v))
+      .map((dataUrl) => ({ id: nanoid(), dataUrl }));
+    if (images.length === 0) {
+      throw new Error("\u63a5\u53e3\u6ca1\u6709\u8fd4\u56de\u56fe\u7247");
+    }
+    return images;
+  },
+
+  ui: {
+    sizeMode: "dynamic",
+    qualitySupported: true,
+    countSupported: true,
+    editSupported: true,
+    useDefaultEndpoint: true,
+  },
+};

--- a/web/src/services/api/image-adapters/index.ts
+++ b/web/src/services/api/image-adapters/index.ts
@@ -1,0 +1,4 @@
+export type { ImageAdapter, ImageResult, PresetSize, ImageAdapterUi } from "./types";
+export { registerAdapter, getAdapter, resolveAdapter, listAdapters } from "./registry";
+export { gptImage2Adapter } from "./gpt-image-2";
+export { seedreamAdapter } from "./seedream";

--- a/web/src/services/api/image-adapters/registry.ts
+++ b/web/src/services/api/image-adapters/registry.ts
@@ -1,0 +1,28 @@
+import type { ImageAdapter } from "./types";
+import { gptImage2Adapter } from "./gpt-image-2";
+import { seedreamAdapter } from "./seedream";
+
+const registry = new Map<string, ImageAdapter>();
+
+export function registerAdapter(adapter: ImageAdapter) {
+  registry.set(adapter.id, adapter);
+}
+
+export function getAdapter(id: string): ImageAdapter | undefined {
+  return registry.get(id);
+}
+
+/** Resolve the correct adapter for a given model name (auto-detect). */
+export function resolveAdapter(model: string): ImageAdapter {
+  const lower = model.toLowerCase();
+  if (lower.includes("seedream")) return seedreamAdapter;
+  return gptImage2Adapter;
+}
+
+export function listAdapters(): ImageAdapter[] {
+  return Array.from(registry.values());
+}
+
+// Register built-in adapters
+registerAdapter(gptImage2Adapter);
+registerAdapter(seedreamAdapter);

--- a/web/src/services/api/image-adapters/seedream.ts
+++ b/web/src/services/api/image-adapters/seedream.ts
@@ -1,0 +1,77 @@
+import { nanoid } from "nanoid";
+import type { AiConfig } from "@/stores/use-config-store";
+import type { ImageAdapter, ImageResult, PresetSize } from "./types";
+
+const SEEDREAM_SIZE_PRESETS: PresetSize[] = [
+  { id: "2K", label: "2K", width: 2048, height: 2048, icon: "square" },
+  { id: "2K-16:9", label: "2K 16:9", width: 2848, height: 1600, icon: "landscape" },
+  { id: "2K-9:16", label: "2K 9:16", width: 1600, height: 2848, icon: "portrait" },
+  { id: "2K-4:3", label: "2K 4:3", width: 2304, height: 1728, icon: "landscape" },
+  { id: "2K-3:4", label: "2K 3:4", width: 1728, height: 2304, icon: "portrait" },
+  { id: "2K-3:2", label: "2K 3:2", width: 2496, height: 1664, icon: "landscape" },
+  { id: "2K-2:3", label: "2K 2:3", width: 1664, height: 2496, icon: "portrait" },
+  { id: "2K-21:9", label: "2K 21:9", width: 3136, height: 1344, icon: "landscape" },
+  { id: "4K", label: "4K", width: 4096, height: 4096, icon: "square" },
+  { id: "4K-16:9", label: "4K 16:9", width: 5504, height: 3040, icon: "landscape" },
+  { id: "4K-9:16", label: "4K 9:16", width: 3040, height: 5504, icon: "portrait" },
+  { id: "4K-4:3", label: "4K 4:3", width: 4704, height: 3520, icon: "landscape" },
+  { id: "4K-3:4", label: "4K 3:4", width: 3520, height: 4704, icon: "portrait" },
+  { id: "4K-3:2", label: "4K 3:2", width: 4992, height: 3328, icon: "landscape" },
+  { id: "4K-2:3", label: "4K 2:3", width: 3328, height: 4992, icon: "portrait" },
+  { id: "4K-21:9", label: "4K 21:9", width: 6240, height: 2656, icon: "landscape" },
+];
+
+function resolveSeedreamSize(config: AiConfig): string | undefined {
+  const raw = (config.size || "auto").trim();
+  if (!raw || raw === "auto") return undefined;
+  const preset = SEEDREAM_SIZE_PRESETS.find((p) => p.id === raw);
+  if (preset) return preset.width + "x" + preset.height;
+  if (/^\d+x\d+$/i.test(raw)) return raw;
+  if (raw.includes(":")) {
+    const parts = raw.split(":");
+    const w = Number(parts[0]);
+    const h = Number(parts[1]);
+    if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {
+      const shortSide = 2048;
+      const longSide = Math.round(shortSide * Math.max(w, h) / Math.min(w, h) / 16) * 16;
+      return w >= h ? longSide + "x" + shortSide : shortSide + "x" + longSide;
+    }
+  }
+  return "2048x2048";
+}
+
+function resolveImageDataUrl(item: Record<string, unknown>) {
+  if (typeof item.b64_json === "string" && item.b64_json) {
+    return "data:image/jpeg;base64," + item.b64_json;
+  }
+  if (typeof item.url === "string" && item.url) return item.url;
+  return null;
+}
+
+export const seedreamAdapter: ImageAdapter = {
+  id: "seedream",
+  name: "Seedream (Volcengine)",
+  buildBody(config: AiConfig, prompt: string, count: number): Record<string, unknown> {
+    const size = resolveSeedreamSize(config);
+    const body: Record<string, unknown> = { model: config.model, prompt, response_format: "b64_json", watermark: false };
+    if (size) body.size = size;
+    if (count > 1) {
+      body.sequential_image_generation = "auto";
+      body.sequential_image_generation_options = { max_images: count };
+    }
+    return body;
+  },
+  parseResponse(raw: unknown): ImageResult[] {
+    let data = raw;
+    // Handle case where proxy returns string body instead of parsed JSON
+    if (typeof data === "string") {
+      try { data = JSON.parse(data); } catch { throw new Error("\u63a5\u53e3\u8fd4\u56de\u5f02\u5e38\uff1a\u4e0d\u662f\u6709\u6548\u7684 JSON"); }
+    }
+    const payload = data as { data?: Record<string, unknown>[] };
+    if (!payload || !Array.isArray(payload.data)) throw new Error("\u63a5\u53e3\u8fd4\u56de\u5f02\u5e38");
+    const images = payload.data.map(resolveImageDataUrl).filter((v): v is string => Boolean(v)).map((dataUrl) => ({ id: nanoid(), dataUrl }));
+    if (images.length === 0) throw new Error("\u63a5\u53e3\u6ca1\u6709\u8fd4\u56de\u56fe\u7247");
+    return images;
+  },
+  ui: { sizeMode: "preset", presetSizes: SEEDREAM_SIZE_PRESETS, qualitySupported: false, countSupported: true, editSupported: false, useDefaultEndpoint: true },
+};

--- a/web/src/services/api/image-adapters/types.ts
+++ b/web/src/services/api/image-adapters/types.ts
@@ -1,0 +1,61 @@
+import type { AiConfig } from "@/stores/use-config-store";
+
+/** Result of parsing an image generation API response */
+export interface ImageResult {
+  id: string;
+  dataUrl: string;
+}
+
+/** A preset size option displayed in the UI */
+export interface PresetSize {
+  id: string;
+  label: string;
+  width: number;
+  height: number;
+  icon?: "square" | "landscape" | "portrait";
+}
+
+/** UI configuration that the settings panel reads to render controls */
+export interface ImageAdapterUi {
+  /** How the size/ratio control works */
+  sizeMode: "dynamic" | "preset" | "none";
+  /** Available presets when sizeMode is "preset" */
+  presetSizes?: PresetSize[];
+  /** Whether the quality control is shown */
+  qualitySupported?: boolean;
+  /** Whether the count (n) control is shown */
+  countSupported?: boolean;
+  /** Whether image editing is supported */
+  editSupported?: boolean;
+  /** Whether this model uses the default OpenAI /images/generations endpoint */
+  useDefaultEndpoint?: boolean;
+}
+
+/**
+ * Each image model gets its own adapter.
+ * The adapter is responsible for:
+ *   - Building the correct request body from user config
+ *   - Parsing the API response
+ *   - Prescribing how the UI settings panel should render
+ */
+export interface ImageAdapter {
+  /** Unique identifier, e.g. "gpt-image-2", "seedream" */
+  id: string;
+  /** Human-readable name */
+  name: string;
+
+  /**
+   * Build the request body for the API call.
+   * URL and headers are handled by the caller (image.ts).
+   */
+  buildBody(config: AiConfig, prompt: string, count: number): Record<string, unknown>;
+
+  /**
+   * Parse the raw API response into ImageResult[].
+   * Throw on error / empty result.
+   */
+  parseResponse(raw: unknown): ImageResult[];
+
+  /** UI configuration */
+  ui: ImageAdapterUi;
+}

--- a/web/src/services/api/image.ts
+++ b/web/src/services/api/image.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 import { buildApiUrl, resolveModelRequestConfig, type AiConfig, type ModelChannel } from "@/stores/use-config-store";
+import { resolveAdapter } from "./image-adapters";
 import { nanoid } from "nanoid";
 import { dataUrlToFile } from "@/lib/image-utils";
 import { buildImageReferencePromptText } from "@/lib/image-reference-prompt";
@@ -625,26 +626,24 @@ export async function requestGeneration(config: AiConfig, prompt: string, option
             throw new Error(readAxiosError(error, "请求失败"));
         }
     }
-    const quality = normalizeQuality(config.quality);
-    const requestSize = resolveRequestSize(quality, config.size);
     try {
-        const response = await axios.post<ImageApiResponse>(
+        console.log("[requestGeneration] Resolving adapter for model:", requestConfig.model);
+        const adapter = resolveAdapter(requestConfig.model);
+        console.log("[requestGeneration] Using adapter:", adapter.id);
+        const body = adapter.buildBody(requestConfig, withSystemPrompt(requestConfig, prompt), n);
+        console.log("[requestGeneration] Request body:", JSON.stringify(body));
+        const response = await axios.post(
             aiApiUrl(requestConfig, "/images/generations"),
-            {
-                model: requestConfig.model,
-                prompt: withSystemPrompt(requestConfig, prompt),
-                n,
-                ...(quality ? { quality } : {}),
-                ...(requestSize ? { size: requestSize } : {}),
-                response_format: "b64_json",
-                output_format: IMAGE_OUTPUT_FORMAT,
-            },
+            body,
             {
                 headers: aiHeaders(requestConfig, "application/json"),
                 signal: options?.signal,
             },
         );
-        const images = parseImagePayload(response.data);
+        console.log("[requestGeneration] Response status:", response.status);
+        console.log("[requestGeneration] Response data type:", typeof response.data);
+        const images = adapter.parseResponse(response.data);
+        console.log("[requestGeneration] Parsed images count:", images.length);
         return images;
     } catch (error) {
         throw new Error(readAxiosError(error, "请求失败"));

--- a/web/src/services/api/image.ts
+++ b/web/src/services/api/image.ts
@@ -228,15 +228,23 @@ function withSystemPrompt(config: AiConfig, prompt: string) {
     return systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
 }
 
+let _proxyTargetUrl = "";
 function aiApiUrl(config: AiConfig, path: string) {
-    return buildApiUrl(config.baseUrl, path);
+    const directUrl = buildApiUrl(config.baseUrl, path);
+    _proxyTargetUrl = directUrl;
+    return config.proxyEnabled ? "/api/ai-proxy" : directUrl;
 }
 
 function aiHeaders(config: AiConfig, contentType?: string) {
-    return {
-        Authorization: `Bearer ${config.apiKey}`,
-        ...(contentType ? { "Content-Type": contentType } : {}),
-    };
+    const headers: Record<string, string> = {};
+    if (config.proxyEnabled) {
+        headers["x-ai-proxy-target"] = _proxyTargetUrl;
+        headers["x-ai-proxy-auth"] = "Bearer " + config.apiKey;
+    } else {
+        headers["Authorization"] = "Bearer " + config.apiKey;
+    }
+    if (contentType) headers["Content-Type"] = contentType;
+    return headers;
 }
 
 function geminiBaseUrl(config: Pick<AiConfig, "baseUrl">) {
@@ -719,7 +727,7 @@ export async function requestToolResponse(config: AiConfig, messages: ResponseIn
     }
 }
 
-export async function fetchImageModels(config: Pick<AiConfig, "baseUrl" | "apiKey" | "apiFormat">) {
+export async function fetchImageModels(config: Pick<AiConfig, "baseUrl" | "apiKey" | "apiFormat"> & { proxyEnabled?: boolean }) {
     try {
         if (config.apiFormat === "gemini") {
             const response = await axios.get<GeminiPayload>(geminiApiUrl({ ...defaultGeminiConfig, ...config }), { headers: geminiHeaders({ ...defaultGeminiConfig, ...config }) });
@@ -729,8 +737,13 @@ export async function fetchImageModels(config: Pick<AiConfig, "baseUrl" | "apiKe
                 .filter((id): id is string => Boolean(id))
                 .sort((a, b) => a.localeCompare(b));
         }
-        const response = await axios.get<{ data?: Array<{ id?: string }>; error?: { message?: string } }>(buildApiUrl(config.baseUrl, "/models"), {
-            headers: {
+        const _proxyEnabled = config.proxyEnabled || false;
+        const _modelUrl = buildApiUrl(config.baseUrl, "/models");
+        const response = await axios.get<{ data?: Array<{ id?: string }>; error?: { message?: string } }>(_proxyEnabled ? "/api/ai-proxy" : _modelUrl, {
+            headers: _proxyEnabled ? {
+                "x-ai-proxy-target": _modelUrl,
+                "x-ai-proxy-auth": "Bearer " + config.apiKey,
+            } : {
                 Authorization: `Bearer ${config.apiKey}`,
             },
         });
@@ -743,8 +756,8 @@ export async function fetchImageModels(config: Pick<AiConfig, "baseUrl" | "apiKe
     }
 }
 
-export async function fetchChannelModels(channel: ModelChannel) {
-    return fetchImageModels({ baseUrl: channel.baseUrl, apiKey: channel.apiKey, apiFormat: channel.apiFormat });
+export async function fetchChannelModels(channel: ModelChannel, proxyEnabled?: boolean) {
+    return fetchImageModels({ baseUrl: channel.baseUrl, apiKey: channel.apiKey, apiFormat: channel.apiFormat, proxyEnabled });
 }
 
 const defaultGeminiConfig: Pick<AiConfig, "baseUrl" | "apiKey" | "apiFormat" | "model" | "systemPrompt"> = {

--- a/web/src/services/api/video.ts
+++ b/web/src/services/api/video.ts
@@ -23,15 +23,24 @@ export type VideoGenerationResult = { blob?: Blob; url?: string; mimeType?: stri
 export type VideoGenerationTask = { id: string; provider: "openai" | "seedance"; model: string };
 export type VideoGenerationTaskState = { status: "pending" } | { status: "completed"; result: VideoGenerationResult } | { status: "failed"; error: string };
 
+let _proxyTargetUrl = "";
+
 function aiApiUrl(config: AiConfig, path: string) {
-    return buildApiUrl(config.baseUrl, path);
+    const directUrl = buildApiUrl(config.baseUrl, path);
+    _proxyTargetUrl = directUrl;
+    return config.proxyEnabled ? "/api/ai-proxy" : directUrl;
 }
 
 function aiHeaders(config: AiConfig, contentType?: string) {
-    return {
-        Authorization: `Bearer ${config.apiKey}`,
-        ...(contentType ? { "Content-Type": contentType } : {}),
-    };
+    const headers: Record<string, string> = {};
+    if (config.proxyEnabled) {
+        headers["x-ai-proxy-target"] = _proxyTargetUrl;
+        headers["x-ai-proxy-auth"] = "Bearer " + config.apiKey;
+    } else {
+        headers["Authorization"] = "Bearer " + config.apiKey;
+    }
+    if (contentType) headers["Content-Type"] = contentType;
+    return headers;
 }
 
 export async function requestVideoGeneration(config: AiConfig, prompt: string, references: ReferenceImage[] = [], videoReferences: ReferenceVideo[] = [], audioReferences: ReferenceAudio[] = [], options?: RequestOptions): Promise<VideoGenerationResult> {
@@ -172,8 +181,11 @@ function assertSeedanceAudioReferences(audioReferences: ReferenceAudio[]) {
 }
 
 function seedanceApiUrl(config: AiConfig, taskId?: string) {
-    return buildApiUrl(config.baseUrl, `/contents/generations/tasks${taskId ? `/${encodeURIComponent(taskId)}` : ""}`);
+    const directUrl = buildApiUrl(config.baseUrl, `/contents/generations/tasks${taskId ? `/${encodeURIComponent(taskId)}` : ""}`);
+    _proxyTargetUrl = directUrl;
+    return config.proxyEnabled ? "/api/ai-proxy" : directUrl;
 }
+
 
 async function buildSeedanceContent(config: AiConfig, prompt: string, references: ReferenceImage[], videoReferences: ReferenceVideo[], audioReferences: ReferenceAudio[]) {
     const content: Array<Record<string, unknown>> = [];

--- a/web/src/stores/use-config-store.ts
+++ b/web/src/stores/use-config-store.ts
@@ -45,6 +45,7 @@ export type AiConfig = {
     size: string;
     count: string;
     canvasImageCount: string;
+    proxyEnabled: boolean;
 };
 
 export type WebdavSyncConfig = {
@@ -100,6 +101,7 @@ export const defaultConfig: AiConfig = {
     size: "1:1",
     count: "1",
     canvasImageCount: "3",
+    proxyEnabled: false,
 };
 
 export const defaultWebdavSyncConfig: WebdavSyncConfig = {
@@ -228,6 +230,7 @@ export const useConfigStore = create<ConfigStore>()(
                         videoGenerateAudio: config.videoGenerateAudio || "true",
                         videoWatermark: config.videoWatermark || "false",
                         canvasImageCount: config.canvasImageCount || "3",
+                        proxyEnabled: config.proxyEnabled ?? false,
                         imageModels: Array.isArray(persistedConfig.imageModels) ? normalizeModelList(config.imageModels, channels) : filterModelsByCapability(models, "image"),
                         videoModels: Array.isArray(persistedConfig.videoModels) ? normalizeModelList(config.videoModels, channels) : filterModelsByCapability(models, "video"),
                         textModels: Array.isArray(persistedConfig.textModels) ? normalizeModelList(config.textModels, channels) : filterModelsByCapability(models, "text"),


### PR DESCRIPTION
- 新增AI接口代理模式（配置界面内设开关），用于绕过浏览器跨域资源共享限制
- 新增/api/ai-proxy路由，在服务端转发AI相关请求
- 在AI配置存储中新增proxyEnabled字段并开启持久化存储
- 图片、音频、视频接口服务支持代理模式
- 修复Docker网络问题：通过host.docker.internal访问主机服务
- 代理路由内自动将127.0.0.1/localhost重写为host.docker.internal
- Docker端口由3000修改为3003，规避端口占用冲突