### PR TITLE
fix: persist retried image generation results to local storage

### DIFF
--- a/web/src/app/(user)/image/page.tsx
+++ b/web/src/app/(user)/image/page.tsx
@@ -298,12 +298,34 @@ export default function ImagePage() {
         }
     };
 
-    const retryResult = (index: number) => {
+    const retryResult = async (index: number) => {
         const snapshot = buildRequestSnapshot();
         if (!snapshot) return;
         setPreviewLog(null);
         setResults((value) => updateResultAt(value, index, { status: "pending", error: undefined, image: undefined }));
-        void runGenerationSlot(index, snapshot).catch(() => {});
+        const retryStartedAt = performance.now();
+        try {
+            const image = await runGenerationSlot(index, snapshot);
+            const stored = await uploadImage(image.dataUrl);
+            const logImage = { ...image, dataUrl: stored.url, storageKey: stored.storageKey, width: stored.width, height: stored.height, bytes: stored.bytes, mimeType: stored.mimeType };
+            setResults((value) => updateResultAt(value, index, { image: { ...image, dataUrl: stored.url, storageKey: stored.storageKey } }));
+            saveLog(
+                buildLog({
+                    prompt: snapshot.text,
+                    model,
+                    config: { ...snapshot.config, count: "1" },
+                    references: snapshot.references,
+                    durationMs: performance.now() - retryStartedAt,
+                    successCount: 1,
+                    failCount: 0,
+                    status: "成功",
+                    images: [logImage],
+                }),
+            );
+            message.success("重试成功");
+        } catch {
+            // runGenerationSlot already updated the result status to "failed"
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary

- When image generation fails and the user retries, the successful result was only held in React state — never persisted to IndexedDB or saved as a log entry
- On page navigation or refresh, the retried image disappeared from history
- Now `retryResult` awaits the generation, uploads the image to persistent storage via `uploadImage`, and creates a log entry via `saveLog` — matching the initial `generate` flow

Closes #71

## Test plan

- [x] Generate an image, force a failure (e.g. invalid API key), click retry with valid config
- [x] Verify retried image appears in generation history after page refresh
- [x] Verify the log entry shows correct metadata (duration, size, model)