### PR TITLE
fix: proxy prompt preview images and preserve history media

### DIFF
--- a/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
+++ b/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
@@ -2503,7 +2503,7 @@ function InfiniteCanvasPage() {
                     onCancelTitleEditing={() => setTitleEditing(false)}
                     canUndo={historyState.canUndo}
                     canRedo={historyState.canRedo}
-                    onHome={() => router.push("/")}
+                    onHome={() => router.push("/canvas")}
                     onProjects={() => router.push("/canvas")}
                     onCreateProject={createAndOpenProject}
                     onDeleteProject={deleteCurrentProject}

--- a/web/src/app/(user)/canvas/[id]/page.tsx
+++ b/web/src/app/(user)/canvas/[id]/page.tsx
@@ -1,5 +1,11 @@
+import { Suspense } from "react";
+
 import CanvasClientPage from "./canvas-client-page";
 
 export default function CanvasPage() {
-    return <CanvasClientPage />;
+    return (
+        <Suspense fallback={<main className="flex h-full items-center justify-center bg-background text-sm text-stone-500">正在加载画布...</main>}>
+            <CanvasClientPage />
+        </Suspense>
+    );
 }

--- a/web/src/app/(user)/canvas/page.tsx
+++ b/web/src/app/(user)/canvas/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { App, Button } from "antd";
 import { Download, FileUp, Plus } from "lucide-react";
@@ -16,6 +16,14 @@ import { useCanvasUiStore } from "./stores/use-canvas-ui-store";
 import { exportCanvasProjects } from "./utils/canvas-export";
 
 export default function CanvasPage() {
+    return (
+        <Suspense fallback={<main className="flex h-full items-center justify-center bg-background text-sm text-stone-500">正在加载画布...</main>}>
+            <CanvasPageContent />
+        </Suspense>
+    );
+}
+
+function CanvasPageContent() {
     const { message } = App.useApp();
     const router = useRouter();
     const searchParams = useSearchParams();

--- a/web/src/app/api/image-proxy/route.ts
+++ b/web/src/app/api/image-proxy/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const allowedHosts = new Set(["pbs.twimg.com"]);
+const allowedHosts = new Set(["pbs.twimg.com", "raw.githubusercontent.com"]);
 
 export async function GET(request: NextRequest) {
     const target = request.nextUrl.searchParams.get("url") || "";
@@ -37,7 +37,8 @@ function parseAllowedImageUrl(value: string) {
         const url = new URL(value);
         if (url.protocol !== "https:") return null;
         if (!allowedHosts.has(url.hostname)) return null;
-        if (!url.pathname.startsWith("/media/")) return null;
+        if (url.hostname === "pbs.twimg.com" && !url.pathname.startsWith("/media/")) return null;
+        if (url.hostname === "raw.githubusercontent.com" && !/\.(?:avif|gif|jpe?g|png|webp)$/i.test(url.pathname)) return null;
         return url;
     } catch {
         return null;

--- a/web/src/app/api/image-proxy/route.ts
+++ b/web/src/app/api/image-proxy/route.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const allowedHosts = new Set(["pbs.twimg.com"]);
+
+export async function GET(request: NextRequest) {
+    const target = request.nextUrl.searchParams.get("url") || "";
+    const url = parseAllowedImageUrl(target);
+    if (!url) return new Response("Invalid image URL", { status: 400 });
+
+    const response = await fetch(url, {
+        headers: {
+            "user-agent": "Mozilla/5.0",
+            accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+        },
+        cache: "force-cache",
+    }).catch(() => null);
+
+    if (!response) return new Response("Image fetch failed", { status: 502 });
+
+    if (!response.ok) return new Response("Image fetch failed", { status: response.status });
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.startsWith("image/")) return new Response("Unsupported content type", { status: 502 });
+
+    return new Response(response.body, {
+        headers: {
+            "content-type": contentType,
+            "cache-control": "public, max-age=604800, stale-while-revalidate=86400",
+        },
+    });
+}
+
+function parseAllowedImageUrl(value: string) {
+    try {
+        const url = new URL(value);
+        if (url.protocol !== "https:") return null;
+        if (!allowedHosts.has(url.hostname)) return null;
+        if (!url.pathname.startsWith("/media/")) return null;
+        return url;
+    } catch {
+        return null;
+    }
+}

--- a/web/src/app/api/prompts/route.ts
+++ b/web/src/app/api/prompts/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
     const filtered = filterPrompts(items, { keyword, category, tags });
 
     return Response.json({
-        items: filtered.slice((page - 1) * pageSize, page * pageSize),
+        items: filtered.slice((page - 1) * pageSize, page * pageSize).map(proxyPromptImages),
         tags: collectTags(withoutTagFilter),
         categories: categories.map((item) => item.category),
         total: filtered.length,
@@ -175,6 +175,28 @@ async function buildDavidWuGptImage2Prompts() {
 
 function defaultPrompt(id: string, title: string, prompt: string, coverUrl: string, tags: string[], preview: string): Omit<Prompt, "category" | "githubUrl"> {
     return { id, title, coverUrl, prompt, tags, preview, createdAt: "", updatedAt: "" };
+}
+
+function proxyPromptImages(item: Prompt): Prompt {
+    return {
+        ...item,
+        coverUrl: proxyImageUrl(item.coverUrl),
+        preview: item.preview.replace(/!\[([^\]]*)]\(([^)]+)\)/g, (match, alt, image) => {
+            const proxied = proxyImageUrl(image);
+            return proxied === image ? match : `![${alt}](${proxied})`;
+        }),
+    };
+}
+
+function proxyImageUrl(image: string) {
+    if (!image) return "";
+    try {
+        const url = new URL(image);
+        if (url.protocol !== "https:" || url.hostname !== "pbs.twimg.com" || !url.pathname.startsWith("/media/")) return image;
+        return `/api/image-proxy?${new URLSearchParams({ url: url.toString() })}`;
+    } catch {
+        return image;
+    }
 }
 
 async function fetchText(baseUrl: string, file: string) {

--- a/web/src/app/api/prompts/route.ts
+++ b/web/src/app/api/prompts/route.ts
@@ -192,11 +192,18 @@ function proxyImageUrl(image: string) {
     if (!image) return "";
     try {
         const url = new URL(image);
-        if (url.protocol !== "https:" || url.hostname !== "pbs.twimg.com" || !url.pathname.startsWith("/media/")) return image;
+        if (!isProxyableImageUrl(url)) return image;
         return `/api/image-proxy?${new URLSearchParams({ url: url.toString() })}`;
     } catch {
         return image;
     }
+}
+
+function isProxyableImageUrl(url: URL) {
+    if (url.protocol !== "https:") return false;
+    if (url.hostname === "pbs.twimg.com") return url.pathname.startsWith("/media/");
+    if (url.hostname === "raw.githubusercontent.com") return /\.(?:avif|gif|jpe?g|png|webp)$/i.test(url.pathname);
+    return false;
 }
 
 async function fetchText(baseUrl: string, file: string) {
@@ -228,7 +235,18 @@ function firstMatch(value: string, pattern: RegExp) {
 }
 
 function extractMarkdownImages(baseUrl: string, markdown: string) {
-    return Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => absoluteImage(baseUrl, match[1])).filter(Boolean);
+    return Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => absoluteImage(baseUrl, match[1])).filter(isPromptPreviewImage);
+}
+
+function isPromptPreviewImage(image: string) {
+    if (!image) return false;
+    try {
+        const url = new URL(image);
+        if (url.hostname === "img.shields.io") return false;
+        return true;
+    } catch {
+        return true;
+    }
 }
 
 function absoluteImage(baseUrl: string, image: string) {

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
                     <h1 className="text-3xl font-semibold tracking-normal">页面不存在</h1>
                     <p className="mt-3 text-sm leading-6 text-stone-500 dark:text-stone-400">这个地址没有对应的页面，可能已经移动或被合并到其他入口。</p>
                     <div className="mt-8 flex flex-wrap justify-center gap-3">
-                        <Link href="/" className="inline-flex h-10 items-center gap-2 rounded-lg bg-stone-950 px-4 text-sm font-medium text-white transition hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-950 dark:hover:bg-stone-200">
+                        <Link href="/canvas" className="inline-flex h-10 items-center gap-2 rounded-lg bg-stone-950 px-4 text-sm font-medium text-white transition hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-950 dark:hover:bg-stone-200">
                             <Home className="size-4" />
                             返回首页
                         </Link>

--- a/web/src/components/layout/app-top-nav.tsx
+++ b/web/src/components/layout/app-top-nav.tsx
@@ -24,7 +24,7 @@ export function AppTopNav() {
                 <header className="sticky top-0 z-20 h-16 shrink-0 border-b border-stone-200 bg-background/90 backdrop-blur-xl dark:border-stone-800">
                     <div className="mx-auto flex h-full max-w-7xl items-stretch justify-between gap-5 px-6">
                         <div className="flex min-w-0 items-center">
-                            <Link href="/" className="flex h-full shrink-0 items-center gap-2 text-sm font-semibold leading-none tracking-tight text-stone-950 transition hover:text-stone-600 dark:text-stone-100 dark:hover:text-stone-300">
+                            <Link href="/canvas" className="flex h-full shrink-0 items-center gap-2 text-sm font-semibold leading-none tracking-tight text-stone-950 transition hover:text-stone-600 dark:text-stone-100 dark:hover:text-stone-300">
                                 <span
                                     className="size-5 shrink-0 bg-current"
                                     style={{

--- a/web/src/components/prompts/prompt-card.tsx
+++ b/web/src/components/prompts/prompt-card.tsx
@@ -23,6 +23,8 @@ export function PromptCard({
     actionType?: "text" | "primary";
     extraAction?: ReactNode;
 }) {
+    const cover = item.coverUrl ? <img src={item.coverUrl} alt={item.title} className="aspect-[4/3] w-full object-cover" /> : <div className="flex aspect-[4/3] w-full items-center justify-center bg-stone-100 text-xs text-stone-400 dark:bg-stone-900 dark:text-stone-500">暂无预览图</div>;
+
     return (
         <Card
             hoverable
@@ -30,7 +32,7 @@ export function PromptCard({
             styles={{ body: { padding: 0 } }}
             cover={
                 <button type="button" className="block w-full text-left" onClick={onOpen}>
-                    <img src={item.coverUrl} alt={item.title} className="aspect-[4/3] w-full object-cover" />
+                    {cover}
                 </button>
             }
         >

--- a/web/src/components/prompts/prompt-detail-dialog.tsx
+++ b/web/src/components/prompts/prompt-detail-dialog.tsx
@@ -13,7 +13,7 @@ export function PromptDetailDialog({ prompt, onClose, onCopy, onSaveAsset }: { p
                     <>
                         <div className="grid gap-5 md:grid-cols-[300px_minmax(0,1fr)]">
                             <div className="space-y-3">
-                                <img src={prompt.coverUrl} alt={prompt.title} className="aspect-[4/3] w-full rounded-lg object-cover" />
+                                {prompt.coverUrl ? <img src={prompt.coverUrl} alt={prompt.title} className="aspect-[4/3] w-full rounded-lg object-cover" /> : <div className="flex aspect-[4/3] w-full items-center justify-center rounded-lg bg-stone-100 text-xs text-stone-400 dark:bg-stone-900 dark:text-stone-500">暂无预览图</div>}
                                 {prompt.preview ? <pre className="max-h-60 overflow-auto whitespace-pre-wrap rounded-lg bg-stone-100 p-3 text-xs leading-5 text-stone-600 dark:bg-stone-900 dark:text-stone-300">{prompt.preview}</pre> : null}
                             </div>
                             <div className="min-w-0">

--- a/web/src/services/generation-log-storage.ts
+++ b/web/src/services/generation-log-storage.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import localforage from "localforage";
+
+const imageLogStore = localforage.createInstance({ name: "infinite-canvas", storeName: "image_generation_logs" });
+const videoLogStore = localforage.createInstance({ name: "infinite-canvas", storeName: "video_generation_logs" });
+
+export async function readGenerationLogReferences() {
+    const [imageLogs, videoLogs] = await Promise.all([readLogs(imageLogStore), readLogs(videoLogStore)]);
+    return { imageLogs, videoLogs };
+}
+
+async function readLogs(store: LocalForage) {
+    const logs: unknown[] = [];
+    await store.iterate((value) => {
+        if (value && typeof value === "object") logs.push(value);
+    });
+    return logs;
+}

--- a/web/src/stores/use-asset-store.ts
+++ b/web/src/stores/use-asset-store.ts
@@ -90,8 +90,10 @@ export const useAssetStore = create<AssetStore>()(
             cleanupImages: (extra) => {
                 window.setTimeout(async () => {
                     const { useCanvasStore } = await import("@/app/(user)/canvas/stores/use-canvas-store");
-                    await cleanupUnusedImages({ assets: get().assets, projects: useCanvasStore.getState().projects, extra });
-                    await cleanupUnusedMedia({ assets: get().assets, projects: useCanvasStore.getState().projects, extra });
+                    const { readGenerationLogReferences } = await import("@/services/generation-log-storage");
+                    const generationLogs = await readGenerationLogReferences();
+                    await cleanupUnusedImages({ assets: get().assets, projects: useCanvasStore.getState().projects, generationLogs, extra });
+                    await cleanupUnusedMedia({ assets: get().assets, projects: useCanvasStore.getState().projects, generationLogs, extra });
                 }, 0);
             },
         }),


### PR DESCRIPTION
## Summary

This PR fixes several production issues found while deploying the Next.js web app behind a same-origin reverse proxy:

- Add a safe same-origin image proxy for prompt preview images from allowed hosts.
- Rewrite `pbs.twimg.com` and `raw.githubusercontent.com` prompt preview images through `/api/image-proxy`.
- Ignore `img.shields.io` badge images when extracting prompt previews, so language badges are not used as covers.
- Show a `暂无预览图` placeholder when a prompt has no real preview image.
- Include image/video generation logs when cleaning local media, preventing history media blobs from being deleted as unused.
- Wrap canvas pages that use `useSearchParams()` in `Suspense` for Next.js 16 production builds.
- Route home/back links to `/canvas` for deployments where the app is mounted under `/canvas`.

## Why

When the app is deployed behind a same-origin proxy, browsers in some regions cannot load Twitter/X CDN images directly, while the server can. This caused prompt preview images to fail with `ERR_CONNECTION_TIMED_OUT`. Some README badge images were also being parsed as prompt covers. Additionally, local media cleanup did not account for generation history logs, so images referenced only by history could be removed.

## Verification

- Ran `npm run build` successfully with Next.js 16.2.3.
- Verified `/api/prompts` rewrites preview images through `/api/image-proxy`.
- Verified proxied `pbs.twimg.com` and `raw.githubusercontent.com` images return `200` with image content types.
- Verified no direct external prompt cover URLs remain after the rewrite.
