### PR TITLE
fix(canvas): wrap useSearchParams in Suspense to fix next build

### DIFF
--- a/docs/content/docs/progress/pending-test.mdx
+++ b/docs/content/docs/progress/pending-test.mdx
@@ -9,3 +9,4 @@ description: 当前版本已实现但仍需人工验证的变更项
 - 配置与用户偏好：每个模型渠道新增 OpenAI / Gemini 调用格式选择，默认 OpenAI，切换默认格式时同步更新默认 Base URL；渠道 Tab 增加紧凑醒目的提醒，说明模型是否可选需要到“模型”Tab 选择。
 - Gemini 调用格式：支持拉取 Gemini 模型列表，并用于文本问答、在线 Agent 工具调用、基础生图和图生图请求。
 - 音频和视频生成：选择 Gemini 调用格式时先给出不支持提示，仍需使用 OpenAI 兼容渠道。
+- Docker 构建：修复 `/canvas` 页面因 `useSearchParams()` 未包裹 `<Suspense>` 边界导致 `next build` 静态预渲染失败、镜像构建中断的问题，需重新执行 `docker build` 验证。

--- a/web/src/app/(user)/canvas/page.tsx
+++ b/web/src/app/(user)/canvas/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { App, Button } from "antd";
 import { Download, FileUp, Plus } from "lucide-react";
@@ -15,7 +15,9 @@ import { useCanvasStore } from "./stores/use-canvas-store";
 import { useCanvasUiStore } from "./stores/use-canvas-ui-store";
 import { exportCanvasProjects } from "./utils/canvas-export";
 
-export default function CanvasPage() {
+// useSearchParams() 在静态预渲染时会触发 CSR bailout，
+// 必须被 Suspense 边界包裹，否则 `next build` 会在生成 /canvas 静态页面时报错。
+function CanvasPageContent() {
     const { message } = App.useApp();
     const router = useRouter();
     const searchParams = useSearchParams();
@@ -124,5 +126,13 @@ export default function CanvasPage() {
             <input ref={inputRef} type="file" accept="application/zip,.zip" className="hidden" onChange={(event) => void importCanvas(event.target.files?.[0])} />
             <CanvasDeleteProjectsDialog />
         </main>
+    );
+}
+
+export default function CanvasPage() {
+    return (
+        <Suspense fallback={<main className="flex h-full items-center justify-center bg-background text-sm text-stone-500">加载中...</main>}>
+            <CanvasPageContent />
+        </Suspense>
     );
 }


### PR DESCRIPTION
The /canvas page called useSearchParams() at the top level of a client component without a Suspense boundary. Next.js requires any component using useSearchParams() to be wrapped in <Suspense>, otherwise static prerendering bails out during `next build` with:

  useSearchParams() should be wrapped in a suspense boundary at page "/canvas"

This broke the Docker image build (bun run build step). Extract the page body into an inner CanvasPageContent component and wrap it with <Suspense> in the default export. No behavioral change.