### PR TITLE
修复 IME 组合输入期间 Enter 误触发提交

### DIFF
--- a/web/src/components/canvas/canvas-agent-chat-ui.tsx
+++ b/web/src/components/canvas/canvas-agent-chat-ui.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Button, Tooltip } from "antd";
 import { ArrowUp, CheckCircle2, CircleAlert, ImagePlus, LoaderCircle, UserRound, Wrench, X, XCircle } from "lucide-react";
 
+import { isPlainEnterKey } from "@/lib/keyboard-event";
 import { canvasThemes } from "@/lib/canvas-theme";
 import type { LocalUser } from "@/stores/use-user-store";
 
@@ -198,7 +199,7 @@ export function AgentChatComposer({
                         void onAddFiles(images);
                     }}
                     onKeyDown={(event) => {
-                        if (event.key !== "Enter" || event.shiftKey || event.ctrlKey || event.metaKey) return;
+                        if (!isPlainEnterKey(event)) return;
                         event.preventDefault();
                         void onSubmit();
                     }}

--- a/web/src/components/canvas/canvas-resource-mention-textarea.tsx
+++ b/web/src/components/canvas/canvas-resource-mention-textarea.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { FileText, Image as ImageIcon, Music2, Video } from "lucide-react";
 
 import { canvasThemes } from "@/lib/canvas-theme";
+import { isImeComposing, isPlainEnterKey } from "@/lib/keyboard-event";
 import { useThemeStore } from "@/stores/use-theme-store";
 import type { CanvasResourceReference } from "@/lib/canvas/canvas-resource-references";
 
@@ -131,6 +132,10 @@ export const CanvasResourceMentionTextarea = forwardRef<HTMLTextAreaElement, Pro
                     props.onPointerUp?.(event);
                 }}
                 onKeyDown={(event) => {
+                    if (isImeComposing(event)) {
+                        onKeyDown?.(event);
+                        return;
+                    }
                     if (mention && candidates.length) {
                         if (event.key === "ArrowDown") {
                             event.preventDefault();
@@ -153,7 +158,7 @@ export const CanvasResourceMentionTextarea = forwardRef<HTMLTextAreaElement, Pro
                             return;
                         }
                     }
-                    if (event.key === "Enter" && onSubmit && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+                    if (isPlainEnterKey(event) && onSubmit) {
                         event.preventDefault();
                         onSubmit();
                         return;

--- a/web/src/lib/keyboard-event.ts
+++ b/web/src/lib/keyboard-event.ts
@@ -1,0 +1,22 @@
+type NativeKeyboardEventLike = {
+    isComposing?: boolean;
+    keyCode?: number;
+    which?: number;
+};
+
+type KeyboardEventLike = NativeKeyboardEventLike & {
+    key?: string;
+    shiftKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    nativeEvent?: NativeKeyboardEventLike;
+};
+
+export function isImeComposing(event: KeyboardEventLike) {
+    const nativeEvent = event.nativeEvent;
+    return Boolean(event.isComposing || nativeEvent?.isComposing || event.keyCode === 229 || event.which === 229 || nativeEvent?.keyCode === 229 || nativeEvent?.which === 229);
+}
+
+export function isPlainEnterKey(event: KeyboardEventLike) {
+    return event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !isImeComposing(event);
+}

--- a/web/tests/ime-keyboard.test.ts
+++ b/web/tests/ime-keyboard.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { isImeComposing, isPlainEnterKey } from "../src/lib/keyboard-event";
+
+type KeyboardEventLike = Parameters<typeof isPlainEnterKey>[0];
+
+function enterEvent(overrides: Partial<KeyboardEventLike> = {}): KeyboardEventLike {
+    return {
+        key: "Enter",
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        ...overrides,
+    };
+}
+
+assert.equal(isPlainEnterKey(enterEvent()), true, "plain Enter submits");
+assert.equal(isPlainEnterKey(enterEvent({ shiftKey: true })), false, "Shift+Enter does not submit");
+assert.equal(isPlainEnterKey(enterEvent({ ctrlKey: true })), false, "Ctrl+Enter does not submit");
+assert.equal(isPlainEnterKey(enterEvent({ metaKey: true })), false, "Meta+Enter does not submit");
+assert.equal(isPlainEnterKey(enterEvent({ nativeEvent: { isComposing: true } })), false, "IME composition Enter does not submit");
+assert.equal(isPlainEnterKey(enterEvent({ nativeEvent: { keyCode: 229 } })), false, "legacy IME Enter does not submit");
+assert.equal(isPlainEnterKey(enterEvent({ key: "a" })), false, "non-Enter keys do not submit");
+
+assert.equal(isImeComposing(enterEvent({ isComposing: true })), true, "direct composition flag is detected");
+assert.equal(isImeComposing(enterEvent({ nativeEvent: { isComposing: true } })), true, "native composition flag is detected");
+assert.equal(isImeComposing(enterEvent({ keyCode: 229 })), true, "direct legacy keyCode composition is detected");
+assert.equal(isImeComposing(enterEvent({ nativeEvent: { keyCode: 229 } })), true, "native legacy keyCode composition is detected");
+assert.equal(isImeComposing(enterEvent()), false, "plain Enter is not composition");
+
+console.log("ime keyboard tests passed");


### PR DESCRIPTION
## 变更说明

修复在 IME 组合输入期间按 Enter 会误触发提交的问题。

目前在 Agent 聊天输入框中使用中文、日文、韩文等输入法时，按 Enter 确认候选词，可能会被页面识别成“发送消息”。资源引用输入框中也存在类似问题，组合输入期间按 Enter 可能会误触发选择引用或提交。

本 PR 增加了统一的键盘事件判断方法，用于识别输入法组合输入状态：

- `event.isComposing`
- `event.nativeEvent.isComposing`
- 部分浏览器/输入法场景下的 `keyCode === 229` / `which === 229`

并应用到以下位置：

- `AgentChatComposer`
- `CanvasResourceMentionTextarea`

这样在 IME 组合输入期间，Enter 会交给输入法处理；只有组合输入结束后的普通 Enter 才会触发发送、选择或提交。

## 验证

已在本地验证：

```bash
tsc --target ES2022 --module commonjs --moduleResolution node --strict --esModuleInterop --skipLibCheck --outDir /tmp/infinite-canvas-upstream-ime-test tests/ime-keyboard.test.ts src/lib/keyboard-event.ts
node /tmp/infinite-canvas-upstream-ime-test/tests/ime-keyboard.test.js
npm run build