### PR TITLE
fix: resolve TypeScript build errors in Tabs onChange and CompactAgentStatus

### DIFF
--- a/web/src/components/layout/app-config-modal.tsx
+++ b/web/src/components/layout/app-config-modal.tsx
@@ -233,7 +233,7 @@ export function AppConfigPanel({ showDoneButton = false, initialTab = "channels"
         <>
             <Tabs
                 activeKey={activeTab}
-                onChange={setActiveTab}
+                onChange={(key) => setActiveTab(key as ConfigTabKey)}
                 items={[
                     {
                         key: "channels",

--- a/web/src/pages/canvas/project.tsx
+++ b/web/src/pages/canvas/project.tsx
@@ -2965,16 +2965,17 @@ function MenuLabel({ text, shortcut }: { text: string; shortcut: string }) {
     );
 }
 
-function CompactAgentStatus({ status, onClick }: { status: { connected: boolean; enabled: boolean; activity: string }; onClick: () => void }) {
+function CompactAgentStatus({ status, onClick }: { status?: { connected: boolean; enabled: boolean; activity: string }; onClick: () => void }) {
     const colorTheme = useThemeStore((state) => state.theme);
     const theme = canvasThemes[colorTheme];
-    const label = status.connected ? "Codex 已连接" : status.enabled ? `Codex ${status.activity || "连接中"}` : "Codex 未连接";
-    const dotColor = status.connected ? "#22c55e" : status.enabled ? "#f59e0b" : theme.node.muted;
+    const agentStatus = status ?? { connected: false, enabled: false, activity: "" };
+    const label = agentStatus.connected ? "Codex 已连接" : agentStatus.enabled ? `Codex ${agentStatus.activity || "连接中"}` : "Codex 未连接";
+    const dotColor = agentStatus.connected ? "#22c55e" : agentStatus.enabled ? "#f59e0b" : theme.node.muted;
     return (
         <button
             type="button"
             className="flex h-8 items-center gap-1.5 text-xs transition hover:opacity-75"
-            style={{ color: status.connected ? "#16a34a" : status.enabled ? "#d97706" : theme.node.muted }}
+            style={{ color: agentStatus.connected ? "#16a34a" : agentStatus.enabled ? "#d97706" : theme.node.muted }}
             onClick={onClick}
             title="打开本地 Codex 面板"
         >


### PR DESCRIPTION
## Problem

`bun run build` (which runs `tsc --noEmit && vite build`) fails on `main` with two TypeScript errors:

```
src/components/layout/app-config-modal.tsx(236,17): error TS2322:
  Type 'Dispatch<SetStateAction<ConfigTabKey>>' is not assignable to type '(activeKey: string) => void'.

src/pages/canvas/project.tsx(2918,41): error TS2322:
  Type '{ connected: boolean; enabled: boolean; activity: string; } | undefined'
  is not assignable to type '{ connected: boolean; enabled: boolean; activity: string; }'.
```

## Fix

1. **`app-config-modal.tsx`** — antd `Tabs` `onChange` provides `(activeKey: string)`, but `setActiveTab` expects `ConfigTabKey`. Wrap it to cast the key:

   ```tsx
   onChange={(key) => setActiveTab(key as ConfigTabKey)}
   ```

2. **`project.tsx`** — `CompactAgentStatus` is called with a possibly-`undefined` `status`, but the prop was typed as required. Make `status` optional and fall back to a default:

   ```tsx
   function CompactAgentStatus({ status, onClick }: { status?: { connected: boolean; enabled: boolean; activity: string }; onClick: () => void }) {
       const agentStatus = status ?? { connected: false, enabled: false, activity: "" };
       // ...uses agentStatus instead of status
   }
   ```

## Testing

- `tsc --noEmit` passes with these changes.
- `vite build` completes successfully.

## Scope

Two-file change, no runtime behavior change beyond making an already-nullable `status` render a "Codex 未连接" default instead of crashing type-check.