### PR TITLE
fix: parse HTML &lt;img&gt; tags and skip badges for prompt cover images

### DIFF
--- a/web/src/services/api/prompts.ts
+++ b/web/src/services/api/prompts.ts
@@ -187,7 +187,9 @@ function firstMatch(value: string, pattern: RegExp) {
 }
 
 function extractMarkdownImages(baseUrl: string, markdown: string) {
-    return Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => absoluteImage(baseUrl, match[1])).filter(Boolean);
+    const markdownImages = Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => match[1]);
+    const htmlImages = Array.from(markdown.matchAll(/<img[^>]*\bsrc=["']([^"']+)["']/gi), (match) => match[1]);
+    return [...markdownImages, ...htmlImages].map((src) => absoluteImage(baseUrl, src)).filter(Boolean);
 }
 
 function absoluteImage(baseUrl: string, image: string) {

--- a/web/src/services/api/prompts.ts
+++ b/web/src/services/api/prompts.ts
@@ -186,10 +186,17 @@ function firstMatch(value: string, pattern: RegExp) {
     return pattern.exec(value)?.[1] || "";
 }
 
+function isBadgeImage(src: string) {
+    return /shields\.io|img\.shields|\/badge\//i.test(src);
+}
+
 function extractMarkdownImages(baseUrl: string, markdown: string) {
     const markdownImages = Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => match[1]);
     const htmlImages = Array.from(markdown.matchAll(/<img[^>]*\bsrc=["']([^"']+)["']/gi), (match) => match[1]);
-    return [...markdownImages, ...htmlImages].map((src) => absoluteImage(baseUrl, src)).filter(Boolean);
+    return [...markdownImages, ...htmlImages]
+        .filter((src) => !isBadgeImage(src))
+        .map((src) => absoluteImage(baseUrl, src))
+        .filter(Boolean);
 }
 
 function absoluteImage(baseUrl: string, image: string) {


### PR DESCRIPTION
## Problem

On the prompt library page (`/prompts`), some cards render a wrong or empty cover image. There are two distinct root causes, both in `extractMarkdownImages` in `web/src/services/api/prompts.ts`.

### 1. HTML `<img>` tags are ignored

The helper only matched Markdown image syntax:

```ts
markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g)
```

But several prompt sources (e.g. `awesome-gpt-image`) mix two image syntaxes in the same README. Some entries use Markdown, others use raw HTML `<img>`:

```html
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d529419b-..." />
```

Entries written with HTML `<img>` produced no extracted image, so `coverUrl` became an empty string and the card rendered `<img src="">` (a black box). Examples: 现实中的名人, 便利店夜景, 《黑神话：悟空》游戏场景.

### 2. shields.io badges get picked as the cover

Some sources (e.g. `awesome-nano-banana-pro-prompts`) start each entry with decorative badges written in Markdown image syntax:

```md
![Language-ZH](https://img.shields.io/badge/Language-ZH-blue)
![Featured](https://img.shields.io/badge/⭐-Featured-gold)
```

The real content image comes later as an HTML `<img>`. Because the first extracted image was a badge, the card cover became a blue "Language" badge and the preview area was filled with badge images instead of the actual generated image.

## Fix

Extend `extractMarkdownImages` to also capture HTML `<img src>`, and filter out shields.io / badge images so only real content images are used for the cover and preview:

```ts
function isBadgeImage(src: string) {
    return /shields\.io|img\.shields|\/badge\//i.test(src);
}

function extractMarkdownImages(baseUrl: string, markdown: string) {
    const markdownImages = Array.from(markdown.matchAll(/!\[[^\]]*]\(([^)]+)\)/g), (match) => match[1]);
    const htmlImages = Array.from(markdown.matchAll(/<img[^>]*\bsrc=["']([^"']+)["']/gi), (match) => match[1]);
    return [...markdownImages, ...htmlImages]
        .filter((src) => !isBadgeImage(src))
        .map((src) => absoluteImage(baseUrl, src))
        .filter(Boolean);
}
```

## Testing

- `tsc --noEmit` passes; `vite build` completes.
- Verified on a deployed build:
  - `awesome-gpt-image`: previously-black cover cards (HTML `<img>` sources) now load correctly.
  - `youmind-nano-banana-pro`: all 20 first-page covers now resolve to the real `cms-assets.youmind.com/...` images with zero badges; previews no longer show badge rows.
- The JSON-based category (`davidwu-gpt-image2-prompts`) is unaffected since it does not go through this helper.

## Scope

Single-file change. No behavior change for entries that already resolved to a correct Markdown image and had no leading badges.