### PR TITLE
feat: render prompt preview images and JSON prompts as a highlighted code block

### DIFF
--- a/web/src/pages/prompts/components/prompt-detail-dialog.tsx
+++ b/web/src/pages/prompts/components/prompt-detail-dialog.tsx
@@ -84,9 +84,11 @@ export function PromptDetailDialog({ prompt, onClose, onCopy, onSaveAsset }: { p
                                     ))}
                                 </div>
                                 <PromptBody prompt={prompt.prompt} onCopy={onCopy} />
-                                <div className="mt-4 text-xs text-stone-500 dark:text-stone-400">
-                                    创建：{formatPromptDate(prompt.createdAt)} · 更新：{formatPromptDate(prompt.updatedAt)}
-                                </div>
+                                {formatPromptDate(prompt.createdAt) || formatPromptDate(prompt.updatedAt) ? (
+                                    <div className="mt-4 text-xs text-stone-500 dark:text-stone-400">
+                                        {[formatPromptDate(prompt.createdAt) && `创建：${formatPromptDate(prompt.createdAt)}`, formatPromptDate(prompt.updatedAt) && `更新：${formatPromptDate(prompt.updatedAt)}`].filter(Boolean).join(" · ")}
+                                    </div>
+                                ) : null}
                                 <Space wrap className="mt-5">
                                     <Button type="primary" icon={<Copy className="size-4" />} onClick={() => onCopy(prompt.prompt)}>
                                         复制提示词

--- a/web/src/pages/prompts/components/prompt-detail-dialog.tsx
+++ b/web/src/pages/prompts/components/prompt-detail-dialog.tsx
@@ -1,7 +1,68 @@
+import { useMemo } from "react";
 import { Copy, FolderPlus } from "lucide-react";
 import { Button, Modal, Space, Tag } from "antd";
+import CodeMirror, { EditorView } from "@uiw/react-codemirror";
+import { json } from "@codemirror/lang-json";
 
 import { formatPromptDate, type Prompt } from "@/services/api/prompts";
+import { useThemeStore } from "@/stores/use-theme-store";
+
+function tryFormatJson(text: string) {
+    const trimmed = text.trim();
+    if (!(trimmed.startsWith("{") && trimmed.endsWith("}")) && !(trimmed.startsWith("[") && trimmed.endsWith("]"))) return null;
+    try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+    } catch {
+        return null;
+    }
+}
+
+function PromptBody({ prompt, onCopy }: { prompt: string; onCopy: (text: string) => void }) {
+    const isDark = useThemeStore((state) => state.theme) === "dark";
+    const formatted = useMemo(() => tryFormatJson(prompt), [prompt]);
+
+    if (formatted === null) {
+        return <p className="mt-4 whitespace-pre-wrap text-sm leading-7 text-stone-800 dark:text-stone-300">{prompt}</p>;
+    }
+
+    return (
+        <div className="mt-4 overflow-hidden rounded-lg border border-stone-200 dark:border-stone-700">
+            <div className="flex items-center justify-between border-b border-stone-200 bg-stone-50 px-3 py-1.5 dark:border-stone-700 dark:bg-stone-900">
+                <span className="rounded bg-stone-200 px-1.5 py-0.5 font-mono text-[11px] font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-300">JSON</span>
+                <Button type="text" size="small" icon={<Copy className="size-3.5" />} onClick={() => onCopy(prompt)}>
+                    复制
+                </Button>
+            </div>
+            <CodeMirror
+                value={formatted}
+                theme={isDark ? "dark" : "light"}
+                editable={false}
+                basicSetup={{ lineNumbers: false, foldGutter: false, highlightActiveLine: false, highlightActiveLineGutter: false }}
+                extensions={[json(), EditorView.lineWrapping]}
+                className="max-h-80 overflow-auto text-xs"
+            />
+        </div>
+    );
+}
+
+function PromptPreview({ preview, coverUrl }: { preview: string; coverUrl: string }) {
+    const imageRegex = /!\[[^\]]*]\(([^)]+)\)/g;
+    const images = Array.from(preview.matchAll(imageRegex), (match) => match[1]).filter((src) => src && src !== coverUrl);
+    const caption = preview.replace(imageRegex, "").trim();
+    if (!images.length && !caption) return null;
+    return (
+        <div className="space-y-3">
+            {images.length ? (
+                <div className="grid grid-cols-2 gap-2">
+                    {images.map((src) => (
+                        <img key={src} src={src} alt="" className="aspect-square w-full rounded-lg object-cover" />
+                    ))}
+                </div>
+            ) : null}
+            {caption ? <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-lg bg-stone-100 p-3 text-xs leading-5 text-stone-600 dark:bg-stone-900 dark:text-stone-300">{caption}</pre> : null}
+        </div>
+    );
+}
 
 export function PromptDetailDialog({ prompt, onClose, onCopy, onSaveAsset }: { prompt: Prompt | null; onClose: () => void; onCopy: (prompt: string) => void; onSaveAsset?: (prompt: Prompt) => void }) {
     return (
@@ -12,7 +73,7 @@ export function PromptDetailDialog({ prompt, onClose, onCopy, onSaveAsset }: { p
                         <div className="grid gap-5 md:grid-cols-[300px_minmax(0,1fr)]">
                             <div className="space-y-3">
                                 <img src={prompt.coverUrl} alt={prompt.title} className="aspect-[4/3] w-full rounded-lg object-cover" />
-                                {prompt.preview ? <pre className="max-h-60 overflow-auto whitespace-pre-wrap rounded-lg bg-stone-100 p-3 text-xs leading-5 text-stone-600 dark:bg-stone-900 dark:text-stone-300">{prompt.preview}</pre> : null}
+                                {prompt.preview ? <PromptPreview preview={prompt.preview} coverUrl={prompt.coverUrl} /> : null}
                             </div>
                             <div className="min-w-0">
                                 <div className="flex flex-wrap gap-1.5">
@@ -22,7 +83,7 @@ export function PromptDetailDialog({ prompt, onClose, onCopy, onSaveAsset }: { p
                                         </Tag>
                                     ))}
                                 </div>
-                                <p className="mt-4 whitespace-pre-wrap text-sm leading-7 text-stone-800 dark:text-stone-300">{prompt.prompt}</p>
+                                <PromptBody prompt={prompt.prompt} onCopy={onCopy} />
                                 <div className="mt-4 text-xs text-stone-500 dark:text-stone-400">
                                     创建：{formatPromptDate(prompt.createdAt)} · 更新：{formatPromptDate(prompt.updatedAt)}
                                 </div>


### PR DESCRIPTION
## Summary

Two UI enhancements to the prompt detail dialog (`web/src/pages/prompts/components/prompt-detail-dialog.tsx`). This is a UX improvement, separate from the cover-image parsing bug fix in #100.

## 1. Render preview images instead of raw markdown text

For sources like `youmind-*`, the `preview` field is a string of markdown image tags (`![](url) ![](url) ...`). The dialog previously dumped this into a `<pre>`, so users saw literal `![](https://...)` text instead of the sample images.

Now the preview extracts those image URLs and renders them as a small image grid (skipping the one already used as the cover). Any non-image caption text (e.g. the English title / note in `davidwu-*`) still renders as text.

## 2. Render JSON prompts as a highlighted code block

Some prompts (e.g. `gpt-image-2` entries like "VR 头显爆炸视图海报") are authored as a JSON object rather than prose:

```json
{
  "type": "产品爆炸视图海报",
  "subject": "VR 头显",
  "style": "..."
}
```

Previously these rendered as a plain paragraph, which looks like a rendering glitch to users. Now, when a prompt successfully parses as JSON, it is shown in a read-only CodeMirror code block with:

- a `JSON` badge,
- JSON syntax highlighting + monospace font,
- line wrapping and a scroll cap,
- its own copy button.

Non-JSON prompts are unchanged (still a normal paragraph). The copy actions always copy the original prompt text verbatim.

## Dependencies

No new dependencies. Uses the already-declared `@uiw/react-codemirror` and `@codemirror/lang-json` from `package.json`. `EditorView` is imported from `@uiw/react-codemirror` (which re-exports `@codemirror/view`), and the dark theme uses react-codemirror's built-in `theme="dark"`, so no undeclared CodeMirror packages are referenced.

## Testing

- `tsc --noEmit` passes; `vite build` completes.
- Verified on a deployed build:
  - `youmind-nano-banana-pro` detail: preview now shows the real sample images (no raw `![]()` text).
  - `gpt-image-2` "VR 头显爆炸视图海报": prompt renders as a highlighted JSON code block with a `JSON` badge and copy button; syntax highlighting confirmed.
  - A normal prose prompt still renders as plain text.

## Note

Pulling CodeMirror into the main entry chunk increases bundle size (the library was previously only an indirect dependency). If you prefer to keep the entry bundle lean, this could be lazy-loaded; happy to adjust based on your preference.