### PR TITLE
feat(config): support URL preference config

### DIFF
--- a/web/src/components/layout/client-root-init.tsx
+++ b/web/src/components/layout/client-root-init.tsx
@@ -3,8 +3,16 @@ import { useEffect, useRef } from "react";
 import { App } from "antd";
 import { useTranslation } from "react-i18next";
 
-import { createModelChannel, useConfigStore } from "@/stores/use-config-store";
+import { normalizeAudioFormatValue, normalizeAudioSpeedValue, normalizeAudioVoiceValue } from "@/lib/audio-generation";
+import { createModelChannel, encodeChannelModel, modelOptionsFromChannels, useConfigStore, type ApiCallFormat, type ModelCapability } from "@/stores/use-config-store";
 import { usePromptSourceScheduler } from "@/hooks/use-prompt-source-scheduler";
+
+const MODEL_PARAMS = [
+    ["imageModel", "image"],
+    ["textModel", "text"],
+    ["videoModel", "video"],
+    ["audioModel", "audio"],
+] as const satisfies ReadonlyArray<readonly ["imageModel" | "textModel" | "videoModel" | "audioModel", ModelCapability]>;
 
 export function ClientRootInit({ children }: { children: ReactNode }) {
     const { message } = App.useApp();
@@ -21,33 +29,65 @@ export function ClientRootInit({ children }: { children: ReactNode }) {
         const searchParams = new URLSearchParams(window.location.search);
         const baseUrl = searchParams.get("baseUrl") || searchParams.get("baseurl");
         const apiKey = searchParams.get("apiKey") || searchParams.get("apikey");
-        if (!baseUrl && !apiKey) return;
+        const apiFormatParam = searchParams.get("apiFormat");
+        const apiFormat: ApiCallFormat | null = apiFormatParam === "openai" || apiFormatParam === "gemini" ? apiFormatParam : null;
+        const canvasImageCount = searchParams.get("canvasImageCount");
+        const audioVoice = searchParams.get("audioVoice");
+        const audioFormat = searchParams.get("audioFormat");
+        const audioSpeed = searchParams.get("audioSpeed");
+        const modelParams = MODEL_PARAMS.map(([key, capability]) => ({ key, capability, value: searchParams.get(key)?.trim() || "" }));
+        const configParamNames = ["baseUrl", "baseurl", "apiKey", "apikey", "apiFormat", "canvasImageCount", "audioVoice", "audioFormat", "audioSpeed", ...MODEL_PARAMS.map(([key]) => key)];
+        if (!configParamNames.some((key) => searchParams.has(key))) return;
+
         handledConfigParams.current = true;
-        searchParams.delete("baseUrl");
-        searchParams.delete("baseurl");
-        searchParams.delete("apiKey");
-        searchParams.delete("apikey");
+        configParamNames.forEach((key) => searchParams.delete(key));
         window.history.replaceState(null, "", `${window.location.pathname}${searchParams.size ? `?${searchParams}` : ""}${window.location.hash}`);
-        const firstChannel = config.channels[0];
-        updateConfig(
-            "channels",
-            firstChannel
-                ? config.channels.map((channel, index) =>
-                      index === 0
-                          ? {
-                                ...channel,
-                                ...(baseUrl ? { baseUrl } : {}),
-                                ...(apiKey ? { apiKey } : {}),
-                            }
-                          : channel,
-                  )
-                : [createModelChannel({ id: "default", name: t("config.channels.defaultName"), baseUrl: baseUrl || undefined, apiKey: apiKey || "" })],
-        );
+
+        const hasModelConfig = modelParams.some((item) => item.value);
+        const hasApiConfig = Boolean(baseUrl || apiKey || apiFormat);
+        if (baseUrl || apiKey || apiFormat || hasModelConfig) {
+            const firstChannel = config.channels[0] ||
+                createModelChannel({
+                    id: "default",
+                    name: t("config.channels.defaultName"),
+                    baseUrl: baseUrl || config.baseUrl,
+                    apiKey: apiKey || config.apiKey,
+                    apiFormat: apiFormat || config.apiFormat,
+                });
+            const models = [...firstChannel.models];
+            modelParams.forEach(({ capability, value }) => {
+                if (!value) return;
+                const index = models.findIndex((model) => model.name === value);
+                if (index >= 0) models[index] = { ...models[index], capability };
+                else models.push({ name: value, capability });
+            });
+            const nextFirstChannel = {
+                ...firstChannel,
+                ...(baseUrl ? { baseUrl } : {}),
+                ...(apiKey ? { apiKey } : {}),
+                ...(apiFormat ? { apiFormat } : {}),
+                models,
+            };
+            const channels = [nextFirstChannel, ...config.channels.slice(1)];
+            updateConfig("channels", channels);
+            if (hasModelConfig) updateConfig("models", modelOptionsFromChannels(channels));
+            modelParams.forEach(({ key, value }) => {
+                if (value) updateConfig(key, encodeChannelModel(nextFirstChannel.id, value));
+            });
+        }
+
         if (baseUrl) updateConfig("baseUrl", baseUrl);
         if (apiKey) updateConfig("apiKey", apiKey);
-        openConfigDialog(false);
-        message.success(t("config.importedDirectConfig"));
-    }, [config.channels, message, openConfigDialog, t, updateConfig]);
+        if (apiFormat) updateConfig("apiFormat", apiFormat);
+        if (canvasImageCount !== null) updateConfig("canvasImageCount", String(Math.max(1, Math.min(15, Math.floor(Math.abs(Number(canvasImageCount)) || 3)))));
+        if (audioVoice !== null) updateConfig("audioVoice", normalizeAudioVoiceValue(audioVoice));
+        if (audioFormat !== null) updateConfig("audioFormat", normalizeAudioFormatValue(audioFormat));
+        if (audioSpeed !== null) updateConfig("audioSpeed", normalizeAudioSpeedValue(audioSpeed));
+        if (hasApiConfig) {
+            openConfigDialog(false);
+            message.success(t("config.importedDirectConfig"));
+        }
+    }, [config, message, openConfigDialog, t, updateConfig]);
 
     return <>{children}</>;
 }


### PR DESCRIPTION
## 变更

- 支持通过 URL 设置 `apiFormat`、默认模型、`canvasImageCount` 和音频偏好
- 复用现有音频校验和模型 capability/channel 结构
- 读取后移除已处理的配置参数，不影响其他 query 参数

## 原因

当前 URL 直配只支持 `baseUrl` 和 `apiKey`，通过 Codex / Agent 打开 Canvas 时，常用偏好仍需要手动设置。

Closes #181