### PR TITLE
Redact credentials in agent CLI stderr output

### DIFF
--- a/canvas-agent/package.json
+++ b/canvas-agent/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "debug": "tsx src/index.ts --debug",
-    "test": "tsx --test src/canvas/session.test.ts src/agent/codex-client.test.ts src/agent/codex-history.test.ts src/agent/message-metadata.test.ts src/skills/store.test.ts",
+    "test": "tsx --test src/canvas/session.test.ts src/agent/codex-client.test.ts src/agent/codex-history.test.ts src/agent/message-metadata.test.ts src/skills/store.test.ts src/utils/agent-runtime.test.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "prepack": "npm run build"

--- a/canvas-agent/src/agent/claude.ts
+++ b/canvas-agent/src/agent/claude.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 
 import { AGENT_PROMPT } from "../config.js";
+import { redactAgentLog } from "../utils/agent-runtime.js";
 import { errorMessage } from "../utils/value.js";
 import type { AgentEmit } from "./types.js";
 
@@ -32,7 +33,7 @@ function pipeJsonLines(child: ReturnType<typeof spawn>, emit: AgentEmit, agent: 
             }
         });
     });
-    child.stderr?.on("data", (chunk) => emit("agent_log", { text: chunk.toString() }));
+    child.stderr?.on("data", (chunk) => emit("agent_log", { text: redactAgentLog(chunk.toString()) }));
     child.on("error", (error) => emit("agent_error", { message: error.message }));
     child.on("close", (code) => emit("agent_done", { agent, code }));
 }

--- a/canvas-agent/src/agent/codex-client.ts
+++ b/canvas-agent/src/agent/codex-client.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import stripAnsi from "strip-ansi";
+import { redactAgentLog } from "../utils/agent-runtime.js";
 
 import { VERSION } from "../config.js";
 import { logger } from "../utils/logger.js";
@@ -79,7 +80,7 @@ export class CodexAppClient {
         child.stdout?.on("data", (chunk) => client.read(chunk.toString()));
         child.stderr?.on("data", (chunk) => {
             if (client.skillDraftActive) return;
-            const text = stripAnsi(chunk.toString()).replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+/, "");
+            const text = redactAgentLog(stripAnsi(chunk.toString()).replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+/, ""));
             logger.warn("Codex app-server stderr", { text });
             emit("agent_log", { text });
         });

--- a/canvas-agent/src/utils/agent-runtime.test.ts
+++ b/canvas-agent/src/utils/agent-runtime.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { redactAgentLog } from "./agent-runtime.js";
+
+test("redactAgentLog masks bearer tokens", () => {
+    assert.equal(redactAgentLog("Error: Bearer abc.def-ghi123=="), "Error: Bearer [REDACTED]");
+    assert.equal(redactAgentLog("bearer 0123456789abcdef"), "bearer [REDACTED]");
+});
+
+test("redactAgentLog masks sk- keys", () => {
+    assert.equal(redactAgentLog("key=sk-abcdefgh1234"), "key=[REDACTED]");
+    assert.equal(redactAgentLog("sk-proj-abcdefghijklmnopqrstuvwxyz"), "[REDACTED]");
+});
+
+test("redactAgentLog masks explicit api-key/token/authorization assignments", () => {
+    assert.equal(redactAgentLog('api_key: "secretvalue123"'), "api_key: [REDACTED]");
+    assert.equal(redactAgentLog("token=my-token-abc"), "token=[REDACTED]");
+    assert.equal(redactAgentLog("API-KEY: foobar"), "API-KEY: [REDACTED]");
+});
+
+test("redactAgentLog keeps text without credentials intact", () => {
+    assert.equal(redactAgentLog("Codex app-server exited: 0"), "Codex app-server exited: 0");
+    assert.equal(redactAgentLog("model: gpt-5"), "model: gpt-5");
+});

--- a/canvas-agent/src/utils/agent-runtime.ts
+++ b/canvas-agent/src/utils/agent-runtime.ts
@@ -1,0 +1,7 @@
+/** Redact bearer tokens, sk- keys, and explicit credential assignments before a string is logged or sent to the browser. */
+export function redactAgentLog(text: string): string {
+    return text
+        .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, "$1[REDACTED]")
+        .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
+        .replace(/((?:api[_-]?key|token|authorization)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi, "$1[REDACTED]");
+}


### PR DESCRIPTION
The structured logger already redacts secret-named fields, but Codex and Claude CLI stderr arrives as free text and is echoed both to the debug log and to the browser event stream. Run it through a redaction pass so tokens or keys that CLIs print on failures do not leak.