### PR TITLE
feat(plugin): add ZCode plugin support for Infinite Canvas

### DIFF
--- a/plugins/infinite-canvas/.zcode-plugin/plugin.json
+++ b/plugins/infinite-canvas/.zcode-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "infinite-canvas",
+  "version": "0.1.0",
+  "description": "Use ZCode to read and operate Infinite Canvas through the local Canvas Agent MCP server.",
+  "author": {
+    "name": "basketikun",
+    "url": "https://canvas.best/"
+  },
+  "homepage": "https://canvas.best/",
+  "repository": "https://github.com/basketikun/infinite-canvas",
+  "license": "AGPL-3.0",
+  "keywords": ["infinite-canvas", "canvas", "mcp", "agent"],
+  "skills": "skills",
+  "mcpServers": {
+    "infinite-canvas": {
+      "command": "npx",
+      "args": ["-y", "@basketikun/canvas-agent@latest", "mcp"]
+    }
+  }
+}

--- a/plugins/infinite-canvas/README.md
+++ b/plugins/infinite-canvas/README.md
@@ -1,8 +1,10 @@
-# Infinite Canvas Codex Plugin
+# Infinite Canvas Plugin
 
-让 Codex 可以打开并操作 Infinite Canvas。
+让 Codex / ZCode 可以打开并操作 Infinite Canvas。
 
 ## 安装
+
+### Codex
 
 macOS / Linux：
 
@@ -24,7 +26,13 @@ codex plugin add infinite-canvas@infinite-canvas-local
 
 Windows CMD 将 `$PWD` 替换为 `%cd%`。
 
-安装后新建一个 Codex 任务，然后输入：
+### ZCode
+
+- 打开 **Settings → Plugin Management → Discover**，点击右上角 **`+`** 添加 marketplace。
+- 选择 **本仓库目录**（`plugins/infinite-canvas`）或本仓库根目录，即可发现 `infinite-canvas` 插件并安装。
+- 或在 ZCode 界面直接以本地目录方式加载该插件目录。
+
+安装后新建一个任务，然后输入：
 
 ```text
 帮我打开并连接到 Infinite Canvas

--- a/plugins/infinite-canvas/marketplace.json
+++ b/plugins/infinite-canvas/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "infinite-canvas-local",
+  "version": 1,
+  "description": "Local marketplace for the Infinite Canvas ZCode plugin.",
+  "plugins": [
+    {
+      "name": "infinite-canvas",
+      "version": "0.1.0",
+      "description": "Use ZCode to read and operate Infinite Canvas through the local Canvas Agent MCP server.",
+      "source": "."
+    }
+  ]
+}


### PR DESCRIPTION
## 概述

为 Infinite Canvas 增加 **ZCode 插件支持**，与现有 Codex 插件对齐。让 ZCode 用户能通过本地 Canvas Agent MCP server 读取、创建并操作画布节点、连接流程、触发生成。

Closes #233

## 改动内容（仅改 `plugins/infinite-canvas/` 目录）

- **新增** `.zcode-plugin/plugin.json` — ZCode 原生插件清单（ZCode 优先读取 `.zcode-plugin/`），`mcpServers` 以官方内联对象形式注册 `infinite-canvas` MCP，指向 `npx @basketikun/canvas-agent@latest mcp`
- **新增** `marketplace.json` — 插件自描述的 marketplace 入口（`source: "."`）
- **修改** `README.md` — 标题与说明泛化，新增 ZCode 安装指引

**保留原有 Codex 插件不变**：`.codex-plugin/plugin.json`、`.mcp.json`、`skills/canvas/SKILL.md`、`skills/open-canvas/SKILL.md` 均未改动。

## 为什么不改 `.codex-plugin/`

ZCode 兼容识别 `.codex-plugin/`，但其 `mcpServers` 字段是 Codex 专用的**字符串引用**（`"./.mcp.json"`），ZCode 不能解析成内联 server 配置。故新增 `.zcode-plugin/plugin.json` 提供 ZCode 原生形态。

## 实测验证

已用标准 MCP stdio 协议拉起 `npx @basketikun/canvas-agent@0.6.0 mcp` 并完成 `initialize` + `tools/list`：

- server 正常握手（`canvas-agent 0.6.0`）
- **成功列出 34 个画布工具**：`site_navigate`、`canvas_get_state`、`canvas_get_selection`、`canvas_apply_ops`、`canvas_create_node`、`canvas_create_text_node`、`canvas_create_generation_flow`、`canvas_generate_image`/`video`/`audio`/`text`、`canvas_run_generation`、`workbench_image_generate`、`workbench_video_generate`、`prompts_search`、`assets_list` 等

插件注册的 MCP 服务真实可用，非空壳。

## 测试

- 本地静态校验：`.zcode-plugin/plugin.json` JSON 合法、`name` 符合 ZCode 命名规范（`^[a-z0-9][a-z0-9._-]{0,127}$`）、`skills`/`mcpServers` 引用路径正确
- 运行期验证：MCP stdio 握手 + `tools/list` 返回 34 个工具（见上）
- 改动范围：仅新增插件元数据文件，无任何业务代码改动